### PR TITLE
Batch Environments

### DIFF
--- a/cloudformation/batch.js
+++ b/cloudformation/batch.js
@@ -80,6 +80,21 @@ const stack = {
                 Path: '/'
             }
         },
+        BatchLaunchTemplate: {
+            Type : 'AWS::EC2::LaunchTemplate',
+            Properties : {
+                LaunchTemplateData: {
+                    BlockDeviceMappings: [{
+                        DeviceName: '/dev/xvda',
+                        Ebs: {
+                            VolumeSize: 100,
+                            VolumeType: 'gp2'
+                        }
+                    }]
+                },
+                LaunchTemplateName: cf.join('-', ['batch', cf.ref('AWS::StackName')]),
+            }
+        },
         BatchComputeEnvironment: {
             Type: 'AWS::Batch::ComputeEnvironment',
             Properties: {
@@ -92,6 +107,7 @@ const stack = {
                     DesiredvCpus: 0,
                     MinvCpus: 0,
                     SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
+                    LaunchTemplate: cf.ref('BatchLaunchTemplate'),
                     Subnets:  [
                         'subnet-de35c1f5',
                         'subnet-e67dc7ea',

--- a/cloudformation/batch.js
+++ b/cloudformation/batch.js
@@ -102,7 +102,7 @@ const stack = {
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
                 ComputeEnvironmentName: cf.join('-', ['batch', cf.ref('AWS::StackName')]),
                 ComputeResources: {
-                    ImageId: 'ami-056807e883f197989',
+                    ImageId: 'ami-07c876cff3f8ae3fe',
                     MaxvCpus: 128,
                     DesiredvCpus: 0,
                     MinvCpus: 0,

--- a/cloudformation/batch.js
+++ b/cloudformation/batch.js
@@ -81,8 +81,8 @@ const stack = {
             }
         },
         BatchLaunchTemplate: {
-            Type : 'AWS::EC2::LaunchTemplate',
-            Properties : {
+            Type: 'AWS::EC2::LaunchTemplate',
+            Properties: {
                 LaunchTemplateData: {
                     BlockDeviceMappings: [{
                         DeviceName: '/dev/xvda',
@@ -107,7 +107,9 @@ const stack = {
                     DesiredvCpus: 0,
                     MinvCpus: 0,
                     SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
-                    LaunchTemplate: cf.ref('BatchLaunchTemplate'),
+                    LaunchTemplate: {
+                          LaunchTemplateName: cf.join('-', ['batch', cf.ref('AWS::StackName')])
+                    },
                     Subnets:  [
                         'subnet-de35c1f5',
                         'subnet-e67dc7ea',

--- a/cloudformation/batch.js
+++ b/cloudformation/batch.js
@@ -101,7 +101,7 @@ const stack = {
             Properties: {
                 Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
-                ComputeEnvironmentName: cf.join('-', ['batch', cf.ref('AWS::StackName')]),
+                ComputeEnvironmentName: cf.join('-', ['batch1', cf.ref('AWS::StackName')]),
                 ComputeResources: {
                     ImageId: 'ami-056807e883f197989',
                     MaxvCpus: 128,
@@ -137,7 +137,7 @@ const stack = {
                     SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
                     LaunchTemplate: {
                           LaunchTemplateId: cf.ref('BatchMegaLaunchTemplate'),
-                          Version: cf.getAtt('BatchLaunchTemplate', 'LatestVersionNumber')
+                          Version: cf.getAtt('BatchMegaLaunchTemplate', 'LatestVersionNumber')
                     },
                     Subnets:  [
                         'subnet-de35c1f5',

--- a/cloudformation/batch.js
+++ b/cloudformation/batch.js
@@ -101,7 +101,7 @@ const stack = {
             Properties: {
                 Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
-                ComputeEnvironmentName: cf.join('-', ['batch1', cf.ref('AWS::StackName')]),
+                ComputeEnvironmentName: cf.join('-', ['batch', cf.ref('AWS::StackName')]),
                 ComputeResources: {
                     ImageId: 'ami-056807e883f197989',
                     MaxvCpus: 128,

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -8,11 +8,11 @@ const batch = new AWS.Batch({
 
 function trigger(event) {
     const jobDefinition = process.env.JOB_DEFINITION;
-    const jobQueue = process.env.JOB_QUEUE;
+    const jobStdQueue = process.env.JOB_STD_QUEUE;
+    const jobMegaQueue = process.env.JOB_MEGA_QUEUE;
     const jobName = process.env.JOB_NAME;
 
     console.error('EVENT: ', JSON.stringify(event));
-
 
     if (typeof event !== 'object' || Array.isArray(event)) {
         throw new Error('event must be Key/Value pairs');
@@ -29,7 +29,7 @@ function trigger(event) {
 
         params = {
             jobDefinition: jobDefinition,
-            jobQueue: jobQueue,
+            jobQueue: jobStdQueue,
             jobName: jobName,
             containerOverrides: {
                 command: ['./task.js'],
@@ -51,7 +51,7 @@ function trigger(event) {
     } else if (event.type === 'collect') {
         params = {
             jobDefinition: jobDefinition,
-            jobQueue: jobQueue,
+            jobQueue: jobMegaQueue,
             jobName: jobName,
             containerOverrides: {
                 command: ['./collect.js'],
@@ -61,7 +61,7 @@ function trigger(event) {
     } else if (event.type === 'sources') {
         params = {
             jobDefinition: jobDefinition,
-            jobQueue: jobQueue,
+            jobQueue: jobStdQueue,
             jobName: jobName,
             containerOverrides: {
                 command: ['./sources.js'],

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -72,6 +72,8 @@ function trigger(event) {
         throw new Error('Unknown event type: ' + event.type);
     }
 
+    console.error(JSON.stringify(params));
+
     batch.submitJob(params, (err, res) => {
         if (err) throw err;
 

--- a/task/collect.js
+++ b/task/collect.js
@@ -73,7 +73,7 @@ async function collect(tmp, collection) {
 
         console.error(`ok - zip created: ${zip}`);
         await upload_collection(zip, collection.name);
-        console.error('ok - global archive uploaded');
+        console.error('ok - archive uploaded');
 
         await update_collection(collection);
     } catch (err) {

--- a/task/collect.js
+++ b/task/collect.js
@@ -14,6 +14,8 @@ const mkdirp = require('mkdirp').sync;
 const AWS = require('aws-sdk');
 const archiver = require('archiver');
 
+const DRIVE = '/tmp';
+
 if (!process.env.AWS_DEFAULT_REGION) {
     process.env.AWS_DEFAULT_REGION = 'us-east-1';
 }
@@ -35,8 +37,6 @@ if (require.main == module) {
 const s3 = new AWS.S3({
     region: process.env.AWS_DEFAULT_REGION
 });
-
-const DRIVE = '/tmp';
 
 async function fetch() {
     let tmp = path.resolve(os.tmpdir(), Math.random().toString(36).substring(2, 15));

--- a/task/collect.js
+++ b/task/collect.js
@@ -36,15 +36,17 @@ const s3 = new AWS.S3({
     region: process.env.AWS_DEFAULT_REGION
 });
 
+const DRIVE = '/tmp';
+
 async function fetch() {
     let tmp = path.resolve(os.tmpdir(), Math.random().toString(36).substring(2, 15));
 
     try {
-        fs.stat('/data')
+        fs.stat(DRIVE)
 
-        tmp = path.resolve('/data/', Math.random().toString(36).substring(2, 15));
+        tmp = path.resolve(DRIVE, Math.random().toString(36).substring(2, 15));
     } catch (err) {
-        console.error('ok - could not find /data drive');
+        console.error(`ok - could not find ${DRIVE}`);
     }
 
     fs.mkdirSync(tmp);

--- a/task/collect.js
+++ b/task/collect.js
@@ -37,8 +37,18 @@ const s3 = new AWS.S3({
 });
 
 async function fetch() {
-    const tmp = path.resolve(os.tmpdir(), Math.random().toString(36).substring(2, 15));
+    let tmp = path.resolve(os.tmpdir(), Math.random().toString(36).substring(2, 15));
+
+    try {
+        fs.stat('/data')
+
+        tmp = path.resolve('/data/', Math.random().toString(36).substring(2, 15));
+    } catch (err) {
+        console.error('ok - could not find /data drive');
+    }
+
     fs.mkdirSync(tmp);
+    console.error(`ok - TMP: ${tmp}`);
 
     try {
         const collections = await fetch_collections();


### PR DESCRIPTION
### Context

Now that we have the full data loaded into a staging server, the collect scripts fail due to a batch limit of 22gb disk.

This creates a new `Mega` batch queue which has a 250gb disk and is currently only used to run `collect` jobs.

The https://github.com/openaddresses/lib has also been updated to be able to manually fire scheduled tasks

```
./cli.js --url http://staging.openaddresses.io schedule fire --type collect
```