### PR TITLE
Rerun JobError

### DIFF
--- a/api/web/src/components/Errors.vue
+++ b/api/web/src/components/Errors.vue
@@ -144,6 +144,7 @@ export default {
             }).catch((err) => {
                 this.$emit('err', err);
             });
+        }
     }
 }
 </script>


### PR DESCRIPTION
### Context

JobErrors can often occur to network problems or other transient errors. This PR adds a JobRerun button directly from the JobError page

