### PR TITLE
Add explicit ContentType

### DIFF
--- a/task/collect.js
+++ b/task/collect.js
@@ -148,6 +148,7 @@ function get_source(tmp, data, stats) {
 function upload_collection(file, name) {
     return new Promise((resolve, reject) => {
         s3.upload({
+            ContentType: 'application/zip',
             Body: fs.createReadStream(file),
             Bucket: process.env.Bucket,
             Key: `${process.env.StackName}/collection-${name}.zip`

--- a/task/lib/job.js
+++ b/task/lib/job.js
@@ -223,6 +223,7 @@ class Job {
                 console.error('ok - found cache', cache[0]);
 
                 await s3.putObject({
+                    ContentType: 'application/zip',
                     Bucket: process.env.Bucket,
                     Key: `${process.env.StackName}/job/${this.job}/cache.zip`,
                     Body: fs.createReadStream(cache[0])
@@ -234,6 +235,7 @@ class Job {
 
             const data = path.resolve(this.tmp, 'out.geojson.gz');
             await s3.putObject({
+                ContentType: 'application/gzip',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/job/${this.job}/source.geojson.gz`,
                 Body: fs.createReadStream(data)
@@ -246,6 +248,7 @@ class Job {
                 console.error('ok - found preview', preview[0]);
 
                 await s3.putObject({
+                    ContentType: 'image/png',
                     Bucket: process.env.Bucket,
                     Key: `${process.env.StackName}/job/${this.job}/source.png`,
                     Body: fs.createReadStream(preview[0])


### PR DESCRIPTION
### Context

S3 Objects can't be viewed in browser directly as they don't have their content-type set on s3.

Closes: https://github.com/openaddresses/batch/issues/59

cc/ @iandees 