### PR TITLE
Map Buildings & Parcels Coverage

### DIFF
--- a/api/lib/map.js
+++ b/api/lib/map.js
@@ -61,7 +61,9 @@ class Map {
                 FROM (
                     SELECT
                         n.code,
-                        JSON_object(ARRAY_AGG(k)::TEXT[], ARRAY_AGG(v)::TEXT[]) AS layers,
+                        addresses,
+                        buildings,
+                        parcels,
                         ST_AsMVTGeom(
                             ST_Transform(geom, 3857),
                             ST_SetSRID(ST_MakeBox2D(
@@ -78,8 +80,9 @@ class Map {
                             map.name,
                             map.code,
                             map.geom,
-                            job.layer AS k,
-                            true AS v
+                            job.layer = 'addresses' AS addresses,
+                            job.layer = 'buildings' AS buildings,
+                            job.layer = 'parcels' AS parcels
                         FROM
                             map INNER JOIN job ON map.id = job.map
                         WHERE
@@ -92,6 +95,9 @@ class Map {
                         )
                     ) n
                     GROUP BY
+                        n.addresses,
+                        n.buildings,
+                        n.parcels,
                         n.code,
                         n.geom
                 ) q

--- a/api/web/src/components/Data.vue
+++ b/api/web/src/components/Data.vue
@@ -71,6 +71,7 @@
             <Coverage
                 @err='$emit("err", $event)'
                 v-on:point='filter.point = $event'
+                :layer='filter.layer'
             />
         </div>
 


### PR DESCRIPTION
### Context

In the near future we will be adding support for buildings and parcels processing to the batch platform. 

This clears the way for supporting this feature by updating the coverage map with support for visualizing the difference between `all`, `addresses`, `buildings` and `parcels`.

The map coverage can be changed by selecting a filter layer other than `any` in the filter dropdown.