### PR TITLE
Added function_get to source_schema_v2

### DIFF
--- a/task/lib/source_schema_v2.json
+++ b/task/lib/source_schema_v2.json
@@ -373,6 +373,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -402,6 +405,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -431,6 +437,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -460,6 +469,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -486,6 +498,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -512,6 +527,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -538,6 +556,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -564,6 +585,9 @@
                         },
                         {
                             "$ref": "#/definitions/function_chain"
+                        },
+                        {
+                            "$ref": "#/definitions/function_get"
                         }
                     ]
                 },
@@ -926,9 +950,37 @@
                             },
                             {
                                 "$ref": "#/definitions/function_chain"
+                            },
+                            ,
+                            {
+                                "$ref": "#/definitions/function_get"
                             }
                         ]
                     }
+                }
+            }
+        },
+        "function_get": {
+            "description": "get",
+            "type": "object",
+            "required": [
+                "function",
+                "field",
+                "index"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "function": {
+                    "type": "string",
+                    "enum": [
+                        "get"
+                    ]
+                },
+                "field": {
+                    "type": "string"
+                },
+                "index": {
+                    "type": "integer"
                 }
             }
         }


### PR DESCRIPTION
Continuation of https://github.com/openaddresses/machine/issues/766

I want to check if the new function_get will work in CI. Now I cannot check it, because batch own copy of schema.
draft here -> https://github.com/openaddresses/openaddresses/pull/4987/commits/ff5e713ce869e602a33bad6571f4dfa1ed8e3c75

Isn't it a good idea to keep the schema in just one place?