### PR TITLE
Actions Draft PR

### DIFF
--- a/.github/workflows/ecr_api.yml
+++ b/.github/workflows/ecr_api.yml
@@ -1,10 +1,17 @@
 name: AWS ECR API
 
-on: [push]
+on:
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - ready_for_review
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v1
 

--- a/.github/workflows/ecr_task.yml
+++ b/.github/workflows/ecr_task.yml
@@ -1,10 +1,17 @@
 name: AWS ECR Task
 
-on: [push]
+on:
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - ready_for_review
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v1
 

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -1,10 +1,17 @@
 name: AWS Lambda
 
-on: [push]
+on:
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - ready_for_review
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v1
 


### PR DESCRIPTION
### Context

Only run actions on active PRs. 

- Saves us money on ECR Storage (fewer builds)
- Saves us money on S3 storage (fewer lambdas)