### PR TITLE
Allow integer query schema

### DIFF
--- a/api/lib/schema.js
+++ b/api/lib/schema.js
@@ -96,10 +96,30 @@ class Schemas {
         const opts = {};
         if (info.query) opts.query = info.query;
         if (info.body) opts.body = info.body;
-        return [
-            parsed[1],
-            this.validate(opts)
-        ];
+
+        const flow = [ parsed[1], [] ]
+
+        if (info.query) flow[1].push(Schemas.query(info.query));
+
+        flow[1].push(this.validate(opts));
+
+        return flow;
+    }
+
+    /**
+     * Express middleware to identify query params that should be integers according to the schema
+     * and attempt to cast them as such to ensure they pass the schema
+     */
+    static query(schema) {
+        return function (req, res, next) {
+            for (const key of Object.keys(req.query)) {
+                if (schema.properties[key] && schema.properties[key].type === 'integer') {
+                    req.query[key] = parseInt(req.query[key]);
+                }
+            }
+
+            return next();
+        }
     }
 
     /**

--- a/api/lib/schema.js
+++ b/api/lib/schema.js
@@ -97,7 +97,7 @@ class Schemas {
         if (info.query) opts.query = info.query;
         if (info.body) opts.body = info.body;
 
-        const flow = [ parsed[1], [] ]
+        const flow = [parsed[1], []];
 
         if (info.query) flow[1].push(Schemas.query(info.query));
 
@@ -119,7 +119,7 @@ class Schemas {
             }
 
             return next();
-        }
+        };
     }
 
     /**


### PR DESCRIPTION
### Context

Integer type definitions in JSON schemas applied to req queries would fail as req queries are always strings

### Actions
- Attempt to cast req.qurey[key] to an integer if the schema requires it