### PR TITLE
CI Priority

### DIFF
--- a/api/lib/run.js
+++ b/api/lib/run.js
@@ -224,7 +224,7 @@ class Run {
 
             try {
                 await jobs[i].generate(pool);
-                await jobs[i].batch();
+                await jobs[i].batch(run.github && run.github.check);
             } catch (err) {
                 // TODO return list of successful ids
                 throw new Err(400, err, 'jobs only partially queued');


### PR DESCRIPTION
### Context

Now that we have a specific priority queue for CI jobs that is elevated above scheduled jobs, differentiate between sending jobs to queues based on the run.github param

cc/ @iandees 