### PR TITLE
OGR Timeout

### DIFF
--- a/task/export.js
+++ b/task/export.js
@@ -170,7 +170,7 @@ function archive(tmp) {
 }
 
 function convert(tmp, loc, exp, job) {
-    const ogr = ogr2ogr(loc)
+    let ogr = ogr2ogr(loc)
         .timeout(600000)
         .skipfailures();
 

--- a/task/export.js
+++ b/task/export.js
@@ -172,7 +172,10 @@ function archive(tmp) {
 function convert(tmp, loc, exp, job) {
     let ogr = ogr2ogr(loc)
         .timeout(600000)
-        .skipfailures();
+        .skipfailures()
+        .onStderr((data) => {
+            console.error(data);
+        })
 
     if (exp.format === 'shapefile') {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Context

One of our awesome backers reported an issue with exporting a large statewide address source as a CSV (exp: 9).

From the logs it has been determined that the source failed due to an internal OGR timeout. This PR standardizes our use of the OGR library for standard timeouts, error handling, and logging.

At the moment the timeout is set to 10 minutes. I'm testing this locally to ensure that conversion happens successfully.