### PR TITLE
Override OpenCollective

### DIFF
--- a/api/lib/level.js
+++ b/api/lib/level.js
@@ -15,7 +15,7 @@ const SPONSORS = [
     new RegExp(/^.*@geocod.io$/),
     new RegExp(/^.*@geocode.earth$/),
     new RegExp(/^.*@smartystreets.com$/),
-    new RegExp(/^.*@mapbox.com$/),
+    new RegExp(/^.*@mapbox.com$/)
 ];
 
 /**

--- a/api/test/level.srv.test.js
+++ b/api/test/level.srv.test.js
@@ -93,6 +93,52 @@ test('Level#all', async (t) =>  {
     t.end();
 });
 
+test('Level#user - override', async (t) =>  {
+    const level = new Level(flight.pool);
+
+    try {
+        const usr = await flight.token('hello');
+
+        const usr_pre = await request({
+            url: 'http://localhost:4999/api/login',
+            method: 'GET',
+            json: true,
+            jar: usr.jar
+        });
+
+        t.deepEquals(usr_pre.body, {
+            uid: usr.user.id,
+            level: 'basic',
+            username: usr.user.username,
+            email: usr.user.email,
+            access: 'user',
+            flags: {}
+        });
+
+        await level.single(usr.user.email);
+
+        const usr_post = await request({
+            url: 'http://localhost:4999/api/login',
+            method: 'GET',
+            json: true,
+            jar: usr.jar
+        });
+
+        t.deepEquals(usr_post.body, {
+            uid: usr.user.id,
+            level: 'sponsor',
+            username: usr.user.username,
+            email: usr.user.email,
+            access: 'user',
+            flags: {}
+        });
+    } catch (err) {
+        t.error(err, 'no errors');
+    }
+
+    t.end();
+});
+
 test('Level#user', async (t) =>  {
     nock('https://api.opencollective.com')
         .post('/graphql/v2')


### PR DESCRIPTION
### Context

Org level sponsors do not have an email address returned by OpenCollective, and therefore cannot be upgraded to their appropriate level automatically.

This PR adds a rudimentary override system and pre-populates it with our current list of org level sponsors and their domain names.

As always, thanks to our sponsors for keeping this project running - and if there is a more suitable domain name I should add just LMK.

