### PR TITLE
Meta Verify

### DIFF
--- a/api/web/public/googlecfc027a1ca15dcdb.html
+++ b/api/web/public/googlecfc027a1ca15dcdb.html
@@ -1,1 +1,0 @@
-google-site-verification: googlecfc027a1ca15dcdb.html

--- a/api/web/public/index.html
+++ b/api/web/public/index.html
@@ -5,6 +5,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
+        <meta name="google-site-verification" content="RtCP-gH0mB8Yqy5Y-aUJzAu8zIgi92E0dkBURfjgl1g" />
+
         <title><%= htmlWebpackPlugin.options.title %></title>
 
         <link type='text/css' href='/assembly.min.css' rel='stylesheet'/>


### PR DESCRIPTION
### Context

I made nginx remove the .html extension for nicer looking urls, but that means we can't verify. Using meta tag verification instead.