### PR TITLE
Tell cloudflare to not touch MVTs

### DIFF
--- a/api/routes/map.js
+++ b/api/routes/map.js
@@ -96,7 +96,7 @@ async function router(schema, config) {
     }, async (req, res) => {
         let tile;
         try {
-            const encodings = req.headers['accept-encoding'].split(',').map(e => e.trim());
+            const encodings = req.headers['accept-encoding'].split(',').map((e) => e.trim());
             if (!encodings.includes('gzip')) throw new Err(400, null, 'Accept-Encoding must include gzip');
 
             tile = await config.cacher.get(Miss(req.query, `tile-fabric-${req.params.z}-${req.params.x}-${req.params.y}`), async () => {

--- a/api/routes/map.js
+++ b/api/routes/map.js
@@ -96,6 +96,9 @@ async function router(schema, config) {
     }, async (req, res) => {
         let tile;
         try {
+            const encodings = req.headers['accept-encoding'].split(',').map(e => e.trim());
+            if (!encodings.includes('gzip')) throw new Err(400, null, 'Accept-Encoding must include gzip');
+
             tile = await config.cacher.get(Miss(req.query, `tile-fabric-${req.params.z}-${req.params.x}-${req.params.y}`), async () => {
                 return await Map.fabric_tile(config.tb, req.params.z, req.params.x, req.params.y);
             }, false);
@@ -110,7 +113,7 @@ async function router(schema, config) {
         res.writeHead(200, {
             'Content-Type': 'application/vnd.mapbox-vector-tile',
             'Content-Encoding': 'gzip',
-            'cache-control: no-transform'
+            'cache-control': 'no-transform'
         });
         res.end(tile);
     });

--- a/api/routes/map.js
+++ b/api/routes/map.js
@@ -109,7 +109,8 @@ async function router(schema, config) {
 
         res.writeHead(200, {
             'Content-Type': 'application/vnd.mapbox-vector-tile',
-            'Content-Encoding': 'gzip'
+            'Content-Encoding': 'gzip',
+            'cache-control: no-transform'
         });
         res.end(tile);
     });


### PR DESCRIPTION
Clouldflare is decompressing and serving MVTs resulting in MapboxGL getting raw-uncompressed MVTs which it is not happy about.