### PR TITLE
Fix Github 500

### DIFF
--- a/api/routes/github.js
+++ b/api/routes/github.js
@@ -30,7 +30,7 @@ async function router(schema, config) {
                 await ci.push(config.pool, req.body);
 
                 res.json(true);
-            } else if (req.headers['x-github-event'] === 'pull_request') {
+            } else if (req.headers['x-github-event'] === 'pull_request' && req.body.action !== 'closed') {
                 await ci.pull(config.pool, req.body);
 
                 res.json(true);


### PR DESCRIPTION
### Context

Closing a PR on openaddresses currently created a 500 as the backend does not differentiate between a PR being opened and a PR being closed