### PR TITLE
Update bearer authorization example

### DIFF
--- a/api/API.md
+++ b/api/API.md
@@ -21,7 +21,7 @@ A valid API token must generated for programatic access
 
 _Example_
 ```
-Authorization: Bearer <api token>
+Authorization: Bearer {api token}
 ```
 
 #### Javascript Fetch Example
@@ -31,7 +31,7 @@ fetch('https://batch.openaddresses.io/api/data', {
     withCredentials: true,
     credentials: 'include',
     headers: {
-        'Authorization': 'oa.1234-your-token-here-5678',
+        'Authorization': 'Bearer oa.1234-your-token-here-5678',
         'Content-Type': 'application/json'
     }
 });


### PR DESCRIPTION
Heya,

I was checking out [the docs](https://batch.openaddresses.io/docs/) today and noticed a couple parts of the bearer authorization example which could be improved.

---

The correct format is `Authorization: <type> <credentials>`, which actually what is written in the code as `Authorization: Bearer <api token>`. Unfortunately it seems like the rendering engine is stripping that syntax:

<img width="409" alt="Screenshot 2021-11-18 at 13 39 44" src="https://user-images.githubusercontent.com/738069/142416882-fd2b8893-57f2-49be-9a84-500711067bca.png">

I changed `<>` to `{}`, not sure if this will fix it, just picked different symbols 🤷‍♂️ 😆 

---

In the example it's written `'Authorization': 'oa.1234-your-token-here-5678'` which I believe should be `'Authorization': 'Bearer oa.1234-your-token-here-5678'`?

<img width="462" alt="Screenshot 2021-11-18 at 13 42 16" src="https://user-images.githubusercontent.com/738069/142417374-d11822a2-b681-406d-831f-794cafe0ed76.png">
