### PR TITLE
Set unique name for validated files

### DIFF
--- a/api/lib/job.js
+++ b/api/lib/job.js
@@ -393,7 +393,7 @@ class Job {
             Key: `${process.env.StackName}/job/${job_id}/validated.geojson.gz`
         });
 
-        return s3.stream(res, `${job.source_name}-${job.layer}-${job.name}.geojson.gz`);
+        return s3.stream(res, `${job.source_name}-${job.layer}-${job.name}-validated.geojson.gz`);
     }
 
     static async data(pool, job_id, res) {


### PR DESCRIPTION
### Context

Validated files are now postfixed with `-validated.geojson.gz to differentiate them from non-validatd files