### PR TITLE
provide HTTP URL in data list response

### DIFF
--- a/api/lib/data.js
+++ b/api/lib/data.js
@@ -98,6 +98,7 @@ class Data {
                 res.job = parseInt(res.job);
                 res.size = parseInt(res.size);
                 res.map = parseInt(res.map);
+                res.http = `https://batch.openaddresses.io/api/job/${res.job}/output/source.geojson.gz`;
                 res.s3 = `s3://${process.env.Bucket}/${process.env.StackName}/job/${res.job}/source.geojson.gz`;
 
                 return res;


### PR DESCRIPTION
Hi @ingalls would you consider making this change to the data listings?

The major benefit for the consumer is we wouldn't need to generate the HTTP URLs manually from the `job` param and would also be beneficial for the server-side as the download URL format could change at a later date from the `https://batch.openaddresses.io/api/job/${job}/output/source.geojson.gz` pattern without breaking integrations.

Just floating the idea for now, I could clean this up and edit the docs etc. if it's something you'd consider merging?

Am I right in saying this URL is currently just a convention rather than being something the API provides explicitely?