### PR TITLE
Remove MailGun

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -37,7 +37,6 @@ export default class Config {
                 this.GithubWebhookSecret = secrets.GithubWebhookSecret;
                 this.CookieSecret = secrets.CookieSecret;
                 this.SharedSecret = process.env.SharedSecret;
-                this.MailGun = secrets.MailGun;
                 this.StackName = process.env.StackName;
 
                 let github = secrets.GitHubKey

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -6,10 +6,6 @@ export default {
             Type: 'String',
             Description: 'OpenCollective API Token'
         },
-        MailGun: {
-            Type: 'String',
-            Description: 'MailGun API Token to send user emails'
-        },
         GithubSecret: {
             Type: 'String',
             Description: 'Github CI Integration Secret'
@@ -223,7 +219,6 @@ export default {
                         { Name: 'MEGA_QUEUE', Value: cf.importValue('mega-queue') },
                         { Name: 'ECS_LOG_LEVEL', Value: 'debug' },
                         { Name: 'MAPBOX_TOKEN', Value: cf.ref('MapboxToken') },
-                        { Name: 'MAILGUN_API_KEY', Value: cf.ref('MailGun') },
                         { Name: 'OPENCOLLECTIVE_API_KEY', Value: cf.ref('OpenCollective') },
                         { Name: 'POSTGRES', Value: cf.join(['postgresql://openaddresses:', cf.ref('DatabasePassword'), '@', cf.getAtt('DBInstanceVPC', 'Endpoint.Address'), ':5432/openaddresses']) },
                         { Name: 'SharedSecret', Value: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/api/signing-secret:SecretString::AWSCURRENT}}') },


### PR DESCRIPTION
### Context

It's easier to maintain a single service so removing MailGun config in favour of the already deployed AWS SES integration
