### PR TITLE
Sources Batch Task

### DIFF
--- a/task/sources.js
+++ b/task/sources.js
@@ -64,7 +64,7 @@ async function cli() {
         await meta.protection(true);
 
         console.error('ok - fetching repo');
-        await fetch(tmp);
+        await fetch_repo(tmp);
         console.error('ok - extracted repo');
 
         console.error('ok - fetching latest sha');
@@ -96,7 +96,7 @@ async function cli() {
     }
 }
 
-async function fetch(tmp) {
+async function fetch_repo(tmp) {
     await pipeline(
         request(`https://github.com/openaddresses/openaddresses/archive/${process.env.OA_BRANCH}.zip`),
         fs.createWriteStream(path.resolve(tmp, 'openaddresses.zip'))


### PR DESCRIPTION
### Context

I had a function named `fetch` that performed the fetch of the repo. With the addition of global fetch this resulted in the script failing after it attempted to perform API options with the expected global fetch .