### PR TITLE
Use the S3 JavaScript SDK's upload function instead of putObject

### DIFF
--- a/task/collect.js
+++ b/task/collect.js
@@ -192,7 +192,7 @@ async function upload_collection(file, name) {
 
     console.error(`ok - s3://${process.env.Bucket}/${process.env.StackName}/collection-${name}.zip`);
 
-    await r2.putObject({
+    await r2.upload({
         ContentType: 'application/zip',
         Body: fs.createReadStream(file),
         Bucket: process.env.R2Bucket,

--- a/task/export.js
+++ b/task/export.js
@@ -104,7 +104,7 @@ async function cli() {
         await convert(tmp, loc, exp, job);
         console.error('ok - converted');
 
-        await s3.putObject({
+        await s3.upload({
             ContentType: 'application/zip',
             Bucket: process.env.Bucket,
             Key: `${process.env.StackName}/export/${exp.id}/export.zip`,
@@ -112,7 +112,7 @@ async function cli() {
         }).promise();
         console.error(`ok - uploaded: s3://${process.env.Bucket}/${process.env.StackName}/export/${exp.id}/export.zip`);
 
-        await r2.putObject({
+        await r2.upload({
             ContentType: 'application/zip',
             Bucket: process.env.R2Bucket,
             Key: `v2.openaddresses.io/${process.env.StackName}/export/${exp.id}/export.zip`,

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -104,7 +104,7 @@ async function cli() {
                 path.resolve(DRIVE, 'borders.tilebase')
             );
 
-            await s3.putObject({
+            await s3.upload({
                 ContentType: 'application/octet-stream',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/borders.tilebase`,
@@ -176,7 +176,7 @@ async function cli() {
                 path.resolve(DRIVE, 'fabric.tilebase')
             );
 
-            await s3.putObject({
+            await s3.upload({
                 ContentType: 'application/octet-stream',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/fabric.tilebase`,

--- a/task/lib/job.js
+++ b/task/lib/job.js
@@ -238,14 +238,14 @@ export default class Job {
         if (cache.length === 1) {
             console.error('ok - found cache', cache[0]);
 
-            await s3.putObject({
+            await s3.upload({
                 ContentType: 'application/zip',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/job/${this.job}/cache.zip`,
                 Body: fs.createReadStream(cache[0])
             }).promise();
 
-            await r2.putObject({
+            await r2.upload({
                 ContentType: 'application/zip',
                 Bucket: process.env.R2Bucket,
                 Key: `v2.openaddresses.io/${process.env.StackName}/job/${this.job}/cache.zip`,
@@ -260,14 +260,14 @@ export default class Job {
 
         this.size = fs.statSync(data).size;
 
-        await s3.putObject({
+        await s3.upload({
             ContentType: 'application/gzip',
             Bucket: process.env.Bucket,
             Key: `${process.env.StackName}/job/${this.job}/source.geojson.gz`,
             Body: fs.createReadStream(data)
         }).promise();
 
-        await r2.putObject({
+        await r2.upload({
             ContentType: 'application/gzip',
             Bucket: process.env.R2Bucket,
             Key: `v2.openaddresses.io/${process.env.StackName}/job/${this.job}/source.geojson.gz`,
@@ -280,14 +280,14 @@ export default class Job {
         if (this.validated) {
             this.validated = await Job.gz(this.validated);
 
-            await s3.putObject({
+            await s3.upload({
                 ContentType: 'application/gzip',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/job/${this.job}/validated.geojson.gz`,
                 Body: fs.createReadStream(this.validated)
             }).promise();
 
-            await r2.putObject({
+            await r2.upload({
                 ContentType: 'application/gzip',
                 Bucket: process.env.R2Bucket,
                 Key: `v2.openaddresses.io/${process.env.StackName}/job/${this.job}/validated.geojson.gz`,
@@ -304,14 +304,14 @@ export default class Job {
         if (preview.length === 1) {
             console.error('ok - found preview', preview[0]);
 
-            await s3.putObject({
+            await s3.upload({
                 ContentType: 'image/png',
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/job/${this.job}/source.png`,
                 Body: fs.createReadStream(preview[0])
             }).promise();
 
-            await r2.putObject({
+            await r2.upload({
                 ContentType: 'image/png',
                 Bucket: process.env.R2Bucket,
                 Key: `v2.openaddresses.io/${process.env.StackName}/job/${this.job}/source.png`,


### PR DESCRIPTION
Fixes https://github.com/openaddresses/openaddresses/issues/6376

Large objects (like the collections) were failing to upload with errors like:

```
EntityTooLarge: Your proposed upload exceeds the maximum allowed object size.
--
at Request.extractError (/usr/local/src/batch/node_modules/aws-sdk/lib/services/s3.js:711:35)
at Request.callListeners (/usr/local/src/batch/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
at Request.emit (/usr/local/src/batch/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
at Request.emit (/usr/local/src/batch/node_modules/aws-sdk/lib/request.js:686:14)
at Request.transition (/usr/local/src/batch/node_modules/aws-sdk/lib/request.js:22:10)
at AcceptorStateMachine.runTo (/usr/local/src/batch/node_modules/aws-sdk/lib/state_machine.js:14:12)
at /usr/local/src/batch/node_modules/aws-sdk/lib/state_machine.js:26:10
at Request.<anonymous> (/usr/local/src/batch/node_modules/aws-sdk/lib/request.js:38:9)
at Request.<anonymous> (/usr/local/src/batch/node_modules/aws-sdk/lib/request.js:688:12)
at Request.callListeners (/usr/local/src/batch/node_modules/aws-sdk/lib/sequential_executor.js:116:18) {
code: 'EntityTooLarge',
region: null,
time: 2023-04-16T16:13:44.479Z,
requestId: null,
extendedRequestId: undefined,
cfId: undefined,
statusCode: 400,
retryable: false,
retryDelay: 13.173899584670723
}
```

Instead of using `putObject()`, we should use the `upload()` API, which will break the stream into chunks and perform several multipart PUT operations, allowing us to avoid the 5GB PutObject limit.