### PR TITLE
Clear data cache on job finish

### DIFF
--- a/api/routes/job.js
+++ b/api/routes/job.js
@@ -288,6 +288,7 @@ export default async function router(schema, config) {
 
             const job = await Job.commit(config.pool, req.params.job, req.body);
             await Run.ping(config.pool, ci, job);
+            await config.cacher.del('data');
 
             return res.json(job.serialize());
         } catch (err) {


### PR DESCRIPTION
This is an attempt to clear the `data` cache (used in the endpoint that shows the list of data at batch.openaddresses.io) when a job finishes.

Likely useful for the discussion that is happening on https://github.com/openaddresses/openaddresses/issues/6376