### PR TITLE
fetch_repo was shadowing the built-in fetch

### DIFF
--- a/task/sources.js
+++ b/task/sources.js
@@ -64,7 +64,7 @@ async function cli() {
         await meta.protection(true);
 
         console.error('ok - fetching repo');
-        await fetch(tmp);
+        await fetch_repo(tmp);
         console.error('ok - extracted repo');
 
         console.error('ok - fetching latest sha');
@@ -96,7 +96,7 @@ async function cli() {
     }
 }
 
-async function fetch(tmp) {
+async function fetch_repo(tmp) {
     await pipeline(
         request(`https://github.com/openaddresses/openaddresses/archive/${process.env.OA_BRANCH}.zip`),
         fs.createWriteStream(path.resolve(tmp, 'openaddresses.zip'))


### PR DESCRIPTION
The "OA_Sources" job from this weekend failed with:

```
[Error: ENOENT: no such file or directory, open '/usr/local/src/batch/https:/api.github.com/repos/openaddresses/openaddresses/commits/master/openaddresses.zip'] {
--
errno: -2,
code: 'ENOENT',
syscall: 'open',
path: '/usr/local/src/batch/https:/api.github.com/repos/openaddresses/openaddresses/commits/master/openaddresses.zip'
}
```

I think this happened because the call to `fetch()` in `get_sha()` ([here](https://github.com/openaddresses/batch/blob/ad8a28124cc0da07986f2a59e849638b5ce26503/task/sources.js#L142))  was calling the `fetch()` in the file instead of the built-in `fetch()` HTTP client.

This renames that `fetch()` to something else so that it doesn't shadow the built-in.