### PR TITLE
Fetch logs from the earliest point

### DIFF
--- a/api/lib/types/job.js
+++ b/api/lib/types/job.js
@@ -255,7 +255,8 @@ export default class Job extends Generic {
         try {
             const res = await cwl.getLogEvents({
                 logGroupName: '/aws/batch/job',
-                logStreamName: this.loglink
+                logStreamName: this.loglink,
+                startFromHead: true
             }).promise();
 
             events = res.events;


### PR DESCRIPTION
Fixes https://github.com/openaddresses/batch/issues/322 by fetching logs from the earliest point in the log stream onward, rather than the most recent logs backward (the default).