### PR TITLE
It looks like /docs/ needs the trailing slash

### DIFF
--- a/api/web/src/pages/App.vue
+++ b/api/web/src/pages/App.vue
@@ -12,7 +12,7 @@
 
             <div class='ms-auto'>
                 <div class='btn-list'>
-                    <a href="/docs" class="btn btn-dark" target="_blank" rel="noreferrer">
+                    <a href="/docs/" class="btn btn-dark" target="_blank" rel="noreferrer">
                         <IconHelp size='32'/>
                     </a>
                     <a v-if='false' href="/map" class="btn btn-dark" target="_blank" rel="noreferrer">


### PR DESCRIPTION
https://batch.openaddresses.io/docs/ works but https://batch.openaddresses.io/docs redirects to http://batch.openaddresses.io:5000/docs/ and times out.

Fixes https://github.com/openaddresses/openaddresses/issues/7173