### PR TITLE
Include data.openaddresses.io in batch job role

### DIFF
--- a/cloudformation/lib/batch.js
+++ b/cloudformation/lib/batch.js
@@ -21,6 +21,10 @@ export default {
                             Action: ['s3:PutObject', 's3:GetObject'],
                             Resource: [cf.join(['arn:aws:s3:::', cf.ref('Bucket'), '/*'])]
                         },{
+                            Effect: 'Allow',
+                            Action: ['s3:GetObject'],
+                            Resource: [cf.join(['arn:aws:s3:::data.openaddresses.io/*'])]
+                        },{
                             Effect: 'Allow' ,
                             Action: ['batch:DescribeJobs'],
                             Resource: ['*']


### PR DESCRIPTION
Sources that have https://data.openaddresses.io as a data source use [this code](https://github.com/openaddresses/batch/blob/master/task/lib/job.js#L110-L128) to make S3 requests to these buckets instead of going through the internet and incurring egress charges. The batch job role here does not have permission to get to the data.openaddresses.io bucket, though, so they fail (like [this job](https://batch.openaddresses.io/job/380762#job:380762:log:1)).

This change adds the bucket to the list of permissions on the role.