### PR TITLE
Increase the body size limit for the Github webhook

### DIFF
--- a/api/routes/github.js
+++ b/api/routes/github.js
@@ -9,7 +9,7 @@ export default async function router(schema, config) {
         group: 'Github',
         auth: 'admin',
         description: 'Callback endpoint for GitHub Webhooks. Should not be called by user functions'
-    }, bodyparser.raw({ type: '*/*' }), async (req, res) => {
+    }, bodyparser.raw({ type: '*/*', limit: '500kb' }), async (req, res) => {
         if (!process.env.GithubSecret) return res.status(400).send('Invalid X-Hub-Signature');
 
         const ci = new CI(config);


### PR DESCRIPTION
The API logs are sprinkled pretty heavily with logs that look like:

```
PayloadTooLargeError: request entity too large
```

The webhooks are fairly big, but they seem to only be 30K or so, so chances are this won't fix the problem. But it's worth a try.