### PR TITLE
Try to fix async Parquet writing

### DIFF
--- a/task/collect.js
+++ b/task/collect.js
@@ -341,9 +341,12 @@ async function parquet_datas(tmp, datas, name) {
         // Read the file and parse it as linefeed-delimited JSON
         const data_stream = fs.createReadStream(resolved_data_filename);
         const data_lines = data_stream.pipe(split());
+
         for await (const line of data_lines) {
             const record = JSON.parse(line);
             const properties = record.properties;
+
+            // GeoParquet expects the geometry as a WKB
             const wkbGeometry = wkx.Geometry.parseGeoJSON(record.geometry).toWkb();
 
             await writer.appendRow({
@@ -362,9 +365,8 @@ async function parquet_datas(tmp, datas, name) {
                 notes: properties.notes
             });
         }
-        data_lines.on('end', () => {
-            console.error(`ok - ${resolved_data_filename} processed and appended to parquet file`);
-        });
+
+        console.error(`ok - ${resolved_data_filename} processed and appended to parquet file`);
     }
 
     await writer.close();

--- a/task/collect.js
+++ b/task/collect.js
@@ -317,58 +317,56 @@ function zip_datas(tmp, datas, name) {
     });
 }
 
-function parquet_datas(tmp, datas, name) {
-    return new Promise((resolve) => {
-        const schema = {
-            source_name: { type: 'UTF8' },
-            geometry: { type: 'BINARY' },
-            id: { type: 'UTF8' },
-            pid: { type: 'UTF8' },
-            number: { type: 'UTF8' },
-            street: { type: 'UTF8' },
-            unit: { type: 'UTF8' },
-            city: { type: 'UTF8' },
-            postcode: { type: 'UTF8' },
-            district: { type: 'UTF8' },
-            region: { type: 'UTF8' },
-            addrtype: { type: 'UTF8' },
-            notes: { type: 'UTF8' }
-        };
-        const writer = parquet.ParquetWriter.openFile(schema, path.resolve(tmp, `${name}.parquet`));
+async function parquet_datas(tmp, datas, name) {
+    const schema = {
+        source_name: { type: 'UTF8' },
+        geometry: { type: 'BINARY' },
+        id: { type: 'UTF8' },
+        pid: { type: 'UTF8' },
+        number: { type: 'UTF8' },
+        street: { type: 'UTF8' },
+        unit: { type: 'UTF8' },
+        city: { type: 'UTF8' },
+        postcode: { type: 'UTF8' },
+        district: { type: 'UTF8' },
+        region: { type: 'UTF8' },
+        addrtype: { type: 'UTF8' },
+        notes: { type: 'UTF8' }
+    };
+    const writer = await parquet.ParquetWriter.openFile(schema, path.resolve(tmp, `${name}.parquet`));
 
-        for (const data of datas) {
-            const resolved_data_filename = path.resolve(tmp, 'sources', data);
+    for (const data of datas) {
+        const resolved_data_filename = path.resolve(tmp, 'sources', data);
 
-            // Read the file and parse it as linefeed-delimited JSON
-            const data_stream = fs.createReadStream(resolved_data_filename);
-            const data_lines = data_stream.pipe(split());
-            data_lines.on('data', (line) => {
-                const record = JSON.parse(line);
-                const properties = record.properties;
-                const wkbGeometry = wkx.Geometry.parseGeoJSON(record.geometry).toWkb();
+        // Read the file and parse it as linefeed-delimited JSON
+        const data_stream = fs.createReadStream(resolved_data_filename);
+        const data_lines = data_stream.pipe(split());
+        for await (const line of data_lines) {
+            const record = JSON.parse(line);
+            const properties = record.properties;
+            const wkbGeometry = wkx.Geometry.parseGeoJSON(record.geometry).toWkb();
 
-                writer.appendRow({
-                    source_name: data,
-                    geometry: wkbGeometry,
-                    id: properties.id,
-                    pid: properties.pid,
-                    number: properties.number,
-                    street: properties.street,
-                    unit: properties.unit,
-                    city: properties.city,
-                    postcode: properties.postcode,
-                    district: properties.district,
-                    region: properties.region,
-                    addrtype: properties.addrtype,
-                    notes: properties.notes
-                });
-            });
-            data_lines.on('end', () => {
-                console.error(`ok - ${resolved_data_filename} processed and appended to parquet file`);
+            await writer.appendRow({
+                source_name: data,
+                geometry: wkbGeometry,
+                id: properties.id,
+                pid: properties.pid,
+                number: properties.number,
+                street: properties.street,
+                unit: properties.unit,
+                city: properties.city,
+                postcode: properties.postcode,
+                district: properties.district,
+                region: properties.region,
+                addrtype: properties.addrtype,
+                notes: properties.notes
             });
         }
+        data_lines.on('end', () => {
+            console.error(`ok - ${resolved_data_filename} processed and appended to parquet file`);
+        });
+    }
 
-        writer.close();
-        return resolve(path.resolve(tmp, `${name}.parquet`));
-    });
+    await writer.close();
+    return path.resolve(tmp, `${name}.parquet`);
 }


### PR DESCRIPTION
My changes to add parquet writing in #394 seemingly never actually got deployed, because when Nick made some changes more recently and presumably did a deploy, the collection builds failed with the following error:

```
# us-midwest
ok - zip created: /tmp/z8h0amnyp4p/us-midwest.zip
ok - s3://v2.openaddresses.io/batch-prod/collection-us-midwest.zip
ok - uploaded: r2://openaddresses/v2.openaddresses.io/batch-prod/collection-us-midwest.zip
ok - archive uploaded
TypeError: writer.close is not a function
    at file:///usr/local/src/batch/collect.js:371:16
    at new Promise (<anonymous>)
    at parquet_datas (file:///usr/local/src/batch/collect.js:321:12)
    at collect (file:///usr/local/src/batch/collect.js:114:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async cli (file:///usr/local/src/batch/collect.js:86:13)
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^
TypeError: writer.close is not a function
    at file:///usr/local/src/batch/collect.js:371:16
    at new Promise (<anonymous>)
    at parquet_datas (file:///usr/local/src/batch/collect.js:321:12)
    at collect (file:///usr/local/src/batch/collect.js:114:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async cli (file:///usr/local/src/batch/collect.js:86:13)
```

This is an attempt to make the parquet building function asynchronous (?) to resolve the `writer.close is not a function` error. My theory is that the `writer` was a Promise to get a writer instead of the actual writer. Removing the wrapper `Promise` and letting the `parquet_datas` function be async itself seems to at least give zero linting errors.