### PR TITLE
Switch to using DuckDB node bindings instead of unmaintained parquet libraries

### DIFF
--- a/task/collect.js
+++ b/task/collect.js
@@ -14,7 +14,7 @@ import { mkdirp } from 'mkdirp';
 import S3 from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import archiver from 'archiver';
-import parquet from '@dsnp/parquetjs';
+import duckdb from 'duckdb';
 import minimist from 'minimist';
 import { Transform } from 'node:stream';
 import wkx from 'wkx';
@@ -318,23 +318,28 @@ function zip_datas(tmp, datas, name) {
 }
 
 async function parquet_datas(tmp, datas, name) {
-    const schema = new parquet.ParquetSchema({
-        source_name: { type: 'UTF8' },
-        geometry: { type: 'BYTE_ARRAY', optional: true },
-        id: { type: 'UTF8', optional: true },
-        pid: { type: 'UTF8', optional: true },
-        number: { type: 'UTF8', optional: true },
-        street: { type: 'UTF8', optional: true },
-        unit: { type: 'UTF8', optional: true },
-        city: { type: 'UTF8', optional: true },
-        postcode: { type: 'UTF8', optional: true },
-        district: { type: 'UTF8', optional: true },
-        region: { type: 'UTF8', optional: true },
-        addrtype: { type: 'UTF8', optional: true },
-        notes: { type: 'UTF8', optional: true }
-    });
-    const writer = await parquet.ParquetWriter.openFile(schema, path.resolve(tmp, `${name}.parquet`));
-    writer.setRowGroupSize(4096);
+    const dbFilePath = path.resolve(tmp, `${name}.duckdb`);
+    const db = new duckdb.Database(dbFilePath);
+    const connection = db.connect();
+
+    const createTableQuery = `
+        CREATE TABLE data (
+            source_name VARCHAR,
+            geometry BLOB,
+            id VARCHAR,
+            pid VARCHAR,
+            number VARCHAR,
+            street VARCHAR,
+            unit VARCHAR,
+            city VARCHAR,
+            postcode VARCHAR,
+            district VARCHAR,
+            region VARCHAR,
+            addrtype VARCHAR,
+            notes VARCHAR
+        );
+    `;
+    await connection.run(createTableQuery);
 
     for (const data of datas) {
         const resolved_data_filename = path.resolve(tmp, 'sources', data);
@@ -351,33 +356,55 @@ async function parquet_datas(tmp, datas, name) {
 
             // GeoParquet expects the geometry as a WKB
             let wkbGeometry = null;
-            // if (record.geometry && record.geometry.type) {
-            //     wkbGeometry = wkx.Geometry.parseGeoJSON(record.geometry).toWkb();
-            // } else {
-            //     console.error(`not ok - ${resolved_data_filename} line ${line_count} has no geometry: ${line}`);
-            //     continue;
-            // }
+            if (record.geometry && record.geometry.type) {
+                wkbGeometry = wkx.Geometry.parseGeoJSON(record.geometry).toWkb();
+            } else {
+                console.error(`not ok - ${resolved_data_filename} line ${line_count} has no geometry: ${line}`);
+                continue;
+            }
 
-            await writer.appendRow({
-                source_name: data,
-                geometry: wkbGeometry,
-                id: properties.id,
-                pid: properties.pid,
-                number: properties.number,
-                street: properties.street,
-                unit: properties.unit,
-                city: properties.city,
-                postcode: properties.postcode,
-                district: properties.district,
-                region: properties.region,
-                addrtype: properties.addrtype,
-                notes: properties.notes
-            });
+            const insertQuery = `
+                INSERT INTO data (
+                    source_name,
+                    geometry,
+                    id,
+                    pid,
+                    number,
+                    street,
+                    unit,
+                    city,
+                    postcode,
+                    district,
+                    region,
+                    addrtype,
+                    notes
+                ) VALUES (
+                    '${data}',
+                    x'${wkbGeometry.toString('hex')}',
+                    '${properties.id}',
+                    '${properties.pid}',
+                    '${properties.number}',
+                    '${properties.street}',
+                    '${properties.unit}',
+                    '${properties.city}',
+                    '${properties.postcode}',
+                    '${properties.district}',
+                    '${properties.region}',
+                    '${properties.addrtype}',
+                    '${properties.notes}'
+                );
+            `;
+            await connection.run(insertQuery);
         }
 
         console.error(`ok - ${resolved_data_filename} processed ${line_count} lines and appended to parquet file`);
     }
 
-    await writer.close();
-    return path.resolve(tmp, `${name}.parquet`);
+    const parquetFilePath = path.resolve(tmp, `${name}.parquet`);
+    const exportQuery = `EXPORT TABLE data TO '${parquetFilePath}' (FORMAT 'parquet')`;
+    await connection.run(exportQuery);
+
+    connection.close();
+
+    return parquetFilePath;
 }

--- a/task/package-lock.json
+++ b/task/package-lock.json
@@ -15,16 +15,15 @@
                 "@aws-sdk/client-s3": "^3.405.0",
                 "@aws-sdk/client-secrets-manager": "^3.363.0",
                 "@aws-sdk/lib-storage": "^3.405.0",
-                "@dsnp/parquetjs": "^1.8.5",
                 "@openaddresses/lib": "^4.4.0",
                 "@supercharge/promise-pool": "^3.0.0",
                 "@turf/turf": "^6.3.0",
                 "archiver": "^6.0.0",
                 "csv-parse": "^5.0.0",
                 "decompress": "^4.2.1",
+                "duckdb": "^1.2.0",
                 "find": "^0.3.0",
                 "glob": "^10.0.0",
-                "i": "^0.3.7",
                 "inquirer": "^9.0.0",
                 "minimist": "^1.2.5",
                 "mkdirp": "^3.0.0",
@@ -1418,30 +1417,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@dsnp/parquetjs": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.8.5.tgz",
-            "integrity": "sha512-7Vei5hvJ7LGpU+ZnQI7wgqaTNq47PI5YGap8f1p1OScpZ4Psh78xqzp1LByW6NREAiyUUBwNkypWaUpTYV73jg==",
-            "license": "MIT",
-            "dependencies": {
-                "@aws-sdk/client-s3": "^3.665.0",
-                "@types/node-int64": "^0.4.32",
-                "@types/thrift": "^0.10.17",
-                "@zenfs/core": "^1.0.2",
-                "brotli-wasm": "^3.0.1",
-                "bson": "6.8.0",
-                "int53": "^1.0.0",
-                "long": "^5.2.3",
-                "node-int64": "^0.4.0",
-                "snappyjs": "^0.7.0",
-                "thrift": "0.21.0",
-                "varint": "^6.0.0",
-                "xxhash-wasm": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=18.18.2"
-            }
-        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
@@ -1574,8 +1549,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
@@ -1746,6 +1720,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1955,6 +1941,136 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.0.tgz",
+            "integrity": "sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "consola": "^3.2.3",
+                "detect-libc": "^2.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "node-fetch": "^2.6.7",
+                "nopt": "^8.0.0",
+                "semver": "^7.5.3",
+                "tar": "^7.4.0"
+            },
+            "bin": {
+                "node-pre-gyp": "bin/node-pre-gyp"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
+            "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+            "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.4",
+                "rimraf": "^5.0.5"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^3.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+            "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+            "license": "ISC",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.0.1",
+                "mkdirp": "^3.0.1",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@mapbox/point-geometry": {
@@ -4547,144 +4663,17 @@
                 "undici-types": "~6.20.0"
             }
         },
-        "node_modules/@types/node-int64": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.32.tgz",
-            "integrity": "sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/q": {
-            "version": "1.5.8",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
-            "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/readable-stream": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
-            "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "safe-buffer": "~5.1.1"
-            }
-        },
-        "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
-        },
-        "node_modules/@types/thrift": {
-            "version": "0.10.17",
-            "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.17.tgz",
-            "integrity": "sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/node-int64": "*",
-                "@types/q": "*"
-            }
-        },
         "node_modules/@types/uuid": {
             "version": "9.0.8",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
             "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
             "license": "MIT"
         },
-        "node_modules/@xterm/xterm": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
-            "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@zenfs/core": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-1.9.5.tgz",
-            "integrity": "sha512-Y8uhXVtsluWysksdyyvEhtlVZ2ldzYPlvxaYZQNLiB0Acun8eJg9mJMkXr7xc409oi6PRYdlwh1+5RL+x3v5ow==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "^22.10.1",
-                "@types/readable-stream": "^4.0.10",
-                "buffer": "^6.0.3",
-                "eventemitter3": "^5.0.1",
-                "readable-stream": "^4.5.2",
-                "utilium": "^1.2.10"
-            },
-            "bin": {
-                "make-index": "scripts/make-index.js",
-                "zci": "scripts/ci-cli.js",
-                "zenfs-test": "scripts/test.js"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://github.com/sponsors/james-pre"
-            }
-        },
-        "node_modules/@zenfs/core/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/@zenfs/core/node_modules/readable-stream": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-            "license": "MIT",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "license": "ISC"
-        },
-        "node_modules/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "license": "MIT",
-            "dependencies": {
-                "event-target-shim": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=6.5"
-            }
         },
         "node_modules/acorn": {
             "version": "8.14.0",
@@ -4714,7 +4703,6 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -4727,7 +4715,6 @@
             "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -4858,8 +4845,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
             "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/archiver": {
             "version": "6.0.2",
@@ -4949,7 +4935,6 @@
             "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
@@ -5062,12 +5047,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/async-limiter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -5265,21 +5244,6 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/brotli-wasm": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
-            "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=v18.0.0"
-            }
-        },
-        "node_modules/browser-or-node": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
-            "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
-            "license": "MIT"
-        },
         "node_modules/browserslist": {
             "version": "4.24.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -5310,15 +5274,6 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/bson": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
-            "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.20.1"
             }
         },
         "node_modules/buffer": {
@@ -5736,7 +5691,6 @@
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "license": "ISC",
-            "optional": true,
             "bin": {
                 "color-support": "bin.js"
             }
@@ -5859,12 +5813,20 @@
                 "quickselect": "^2.0.0"
             }
         },
+        "node_modules/consola": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
@@ -6388,8 +6350,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/density-clustering": {
             "version": "1.3.0",
@@ -6427,6 +6388,341 @@
             },
             "bin": {
                 "ignored": "bin/ignored"
+            }
+        },
+        "node_modules/duckdb": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.2.0.tgz",
+            "integrity": "sha512-zAHHRTMoZhWIwvOsyNkgV9c1nq0gR0j+ZyX0uTCRFZTNOlYO4lnErP5Fddt/6iKMXsTNL9v1oTG9E76S5jMh7w==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@mapbox/node-pre-gyp": "^2.0.0",
+                "node-addon-api": "^7.0.0",
+                "node-gyp": "^9.3.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/@npmcli/fs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+            "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/@npmcli/move-file": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+            "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "license": "MIT",
+            "dependencies": {
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/duckdb/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/cacache": {
+            "version": "16.1.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/cacache/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/duckdb/node_modules/cacache/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/duckdb/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/duckdb/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "license": "MIT",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/duckdb/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/duckdb/node_modules/make-fetch-happen": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+            "license": "ISC",
+            "dependencies": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.1.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^9.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/duckdb/node_modules/minipass-fetch": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+            "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/duckdb/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/duckdb/node_modules/node-gyp": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+            "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^6.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^12.13 || ^14.13 || >=16"
+            }
+        },
+        "node_modules/duckdb/node_modules/nopt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^1.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "license": "MIT",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/duckdb/node_modules/socks-proxy-agent": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/duckdb/node_modules/ssri": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+            "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/unique-filename": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+            "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/duckdb/node_modules/unique-slug": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+            "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/dunder-proto": {
@@ -6528,7 +6824,6 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6537,8 +6832,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
             "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/es-abstract": {
             "version": "1.23.9",
@@ -6989,21 +7283,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-            "license": "MIT"
-        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -7021,6 +7300,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/exponential-backoff": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+            "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+            "license": "Apache-2.0"
         },
         "node_modules/extend": {
             "version": "3.0.2",
@@ -7400,7 +7685,6 @@
             "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
                 "color-support": "^1.1.3",
@@ -7419,8 +7703,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -7809,8 +8092,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/hasha": {
             "version": "5.2.2",
@@ -7871,8 +8153,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "license": "BSD-2-Clause",
-            "optional": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
@@ -7909,7 +8190,6 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -7923,17 +8203,8 @@
             "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "ms": "^2.0.0"
-            }
-        },
-        "node_modules/i": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-            "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
-            "engines": {
-                "node": ">=0.4"
             }
         },
         "node_modules/iconv-lite": {
@@ -8017,8 +8288,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -8066,12 +8336,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/int53": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
-            "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/internal-slot": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -8092,7 +8356,6 @@
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
             "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "jsbn": "1.1.0",
                 "sprintf-js": "^1.1.3"
@@ -8105,8 +8368,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
             "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/is-arguments": {
             "version": "1.2.0",
@@ -8336,8 +8598,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
             "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -8566,15 +8827,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
-        },
-        "node_modules/isomorphic-ws": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ws": "*"
-            }
         },
         "node_modules/isstream": {
             "version": "0.1.2",
@@ -9011,12 +9263,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/long": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
-            "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
-            "license": "Apache-2.0"
-        },
         "node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -9184,7 +9430,6 @@
             "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
             "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9197,7 +9442,6 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9241,7 +9485,6 @@
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
             "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9254,7 +9497,6 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9267,7 +9509,6 @@
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9280,7 +9521,6 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9293,7 +9533,6 @@
             "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
             "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9306,7 +9545,6 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9421,7 +9659,6 @@
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
             "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -9457,6 +9694,26 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "license": "MIT"
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/node-gyp": {
             "version": "8.4.1",
@@ -9520,12 +9777,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/node-int64": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "license": "MIT"
         },
         "node_modules/node-preload": {
             "version": "0.2.1",
@@ -12117,7 +12368,6 @@
             "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
                 "console-control-strings": "^1.1.0",
@@ -13122,15 +13372,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -13153,15 +13394,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
             "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "err-code": "^2.0.2",
                 "retry": "^0.12.0"
@@ -13524,7 +13763,6 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -13944,24 +14182,16 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
             }
-        },
-        "node_modules/snappyjs": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.7.0.tgz",
-            "integrity": "sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==",
-            "license": "MIT"
         },
         "node_modules/socks": {
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
             "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
@@ -14074,8 +14304,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause",
-            "optional": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/sqlite3": {
             "version": "5.1.7",
@@ -14602,22 +14831,6 @@
                 "b4a": "^1.6.4"
             }
         },
-        "node_modules/thrift": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.21.0.tgz",
-            "integrity": "sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "browser-or-node": "^1.2.1",
-                "isomorphic-ws": "^4.0.1",
-                "node-int64": "^0.4.0",
-                "q": "^1.5.0",
-                "ws": "^5.2.3"
-            },
-            "engines": {
-                "node": ">= 10.18.0"
-            }
-        },
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -14759,6 +14972,12 @@
             "engines": {
                 "node": ">=0.8"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/traverse": {
             "version": "0.3.9",
@@ -15065,22 +15284,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
-        "node_modules/utilium": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/utilium/-/utilium-1.3.0.tgz",
-            "integrity": "sha512-4y6XMgs59V519AR9SFpArgJURQcKSbczN18ify/k1CXzqcvyqm0sQf15CzVnL8uVGtVvnvJXaGbIuXgz5mWxAg==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://github.com/sponsors/james-pre"
-            },
-            "optionalDependencies": {
-                "@xterm/xterm": "^5.5.0"
-            }
-        },
         "node_modules/uuid": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -15093,12 +15296,6 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
-        },
-        "node_modules/varint": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-            "license": "MIT"
         },
         "node_modules/verror": {
             "version": "1.10.0",
@@ -15123,6 +15320,12 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/wellknown": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.5.0.tgz",
@@ -15134,6 +15337,16 @@
             },
             "bin": {
                 "wellknown": "cli.js"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -15249,7 +15462,6 @@
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
             "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
@@ -15329,15 +15541,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
-        "node_modules/ws": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-            "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
-            "license": "MIT",
-            "dependencies": {
-                "async-limiter": "~1.0.0"
-            }
-        },
         "node_modules/xml2js": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -15368,12 +15571,6 @@
             "engines": {
                 "node": ">=0.4"
             }
-        },
-        "node_modules/xxhash-wasm": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-            "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-            "license": "MIT"
         },
         "node_modules/y18n": {
             "version": "4.0.3",

--- a/task/package.json
+++ b/task/package.json
@@ -22,7 +22,7 @@
         "@aws-sdk/client-s3": "^3.405.0",
         "@aws-sdk/client-secrets-manager": "^3.363.0",
         "@aws-sdk/lib-storage": "^3.405.0",
-        "@dsnp/parquetjs": "^1.8.5",
+        "duckdb": "^1.2.0",
         "@openaddresses/lib": "^4.4.0",
         "@supercharge/promise-pool": "^3.0.0",
         "@turf/turf": "^6.3.0",


### PR DESCRIPTION
Follows #394 

None of the parquet libraries seem to work (they get tripped up by memory leaks), so I'm trying DuckDB bindings instead.