### PR TITLE
Switch DuckDB node bindings

### DIFF
--- a/task/collect.js
+++ b/task/collect.js
@@ -14,7 +14,7 @@ import { mkdirp } from 'mkdirp';
 import S3 from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import archiver from 'archiver';
-import duckdb from 'duckdb';
+import { DuckDBInstance } from '@duckdb/node-api';
 import minimist from 'minimist';
 import { Transform } from 'node:stream';
 import wkx from 'wkx';
@@ -319,7 +319,7 @@ function zip_datas(tmp, datas, name) {
 
 async function parquet_datas(tmp, datas, name) {
     const dbFilePath = path.resolve(tmp, `${name}.duckdb`);
-    const db = new duckdb.Database(dbFilePath);
+    const db = await DuckDBInstance.create(dbFilePath);
     const connection = db.connect();
 
     const createTableQuery = `

--- a/task/package-lock.json
+++ b/task/package-lock.json
@@ -15,13 +15,13 @@
                 "@aws-sdk/client-s3": "^3.405.0",
                 "@aws-sdk/client-secrets-manager": "^3.363.0",
                 "@aws-sdk/lib-storage": "^3.405.0",
+                "@duckdb/node-api": "^1.2.0-alpha.15",
                 "@openaddresses/lib": "^4.4.0",
                 "@supercharge/promise-pool": "^3.0.0",
                 "@turf/turf": "^6.3.0",
                 "archiver": "^6.0.0",
                 "csv-parse": "^5.0.0",
                 "decompress": "^4.2.1",
-                "duckdb": "^1.2.0",
                 "find": "^0.3.0",
                 "glob": "^10.0.0",
                 "inquirer": "^9.0.0",
@@ -1417,6 +1417,93 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@duckdb/node-api": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-XFnBcl3qe9FwFXAxHriGB59VbEpu3a7Xk7JSYCQI+N7i40O0FyEplgLxlkJKjSoKAlMJyA64MhBF6HbBCRMoCg==",
+            "license": "MIT",
+            "dependencies": {
+                "@duckdb/node-bindings": "1.2.0-alpha.15"
+            }
+        },
+        "node_modules/@duckdb/node-bindings": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-HJYfXbMaFRMkOI2dCxgBo9gMeXoe+BlieCI19U2f9fdrwWU2/nwAPHYxvtJJBPJ33eHCzA1ubJBtLsmXXujZSQ==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@duckdb/node-bindings-darwin-arm64": "1.2.0-alpha.15",
+                "@duckdb/node-bindings-darwin-x64": "1.2.0-alpha.15",
+                "@duckdb/node-bindings-linux-arm64": "1.2.0-alpha.15",
+                "@duckdb/node-bindings-linux-x64": "1.2.0-alpha.15",
+                "@duckdb/node-bindings-win32-x64": "1.2.0-alpha.15"
+            }
+        },
+        "node_modules/@duckdb/node-bindings-darwin-arm64": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-gcUI8e7x55Kh3T5ir5s91IqlsCgkKSsyEfDfPKW0w4PHctgKlod76uoBZMbmtx1vrFSW8ml1vLddWVOYDZH53g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@duckdb/node-bindings-darwin-x64": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-rzx37eaeN4xKN7S06lES2lrT3mD8YHJq5l1pk8b0OevUa8WO5LW/kW3KrX2pkGqWq4E5b2MVLwH5Yhv6MN00jg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@duckdb/node-bindings-linux-arm64": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-fPDSjLa1CLJ8Wydbfoc/Mwxs8z0+/xSCfkFml1/mI9u+qXqXj00Sccyjxufm5oy3kqiyvGc5dPygGKN5OuXwaA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@duckdb/node-bindings-linux-x64": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-Fl4MKgpwBw9SKhci3EXnOKGBxcZw6nwSg481FkqPH3cMe2Qu6AbVhORVSgoacIWFQe7srVbd37fWKd+uM1bvqg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@duckdb/node-bindings-win32-x64": {
+            "version": "1.2.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.2.0-alpha.15.tgz",
+            "integrity": "sha512-OueDaXe+zalmTz4Qiy6hfNkRIzVkOxLZj+l6OqsAx040hJVUCy8yDqRq1J7a1IzfiEobxBU4WBWGQEEyva/TqA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
@@ -1549,7 +1636,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
@@ -1720,18 +1808,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^7.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1941,136 +2017,6 @@
             },
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.0.tgz",
-            "integrity": "sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "consola": "^3.2.3",
-                "detect-libc": "^2.0.0",
-                "https-proxy-agent": "^7.0.5",
-                "node-fetch": "^2.6.7",
-                "nopt": "^8.0.0",
-                "semver": "^7.5.3",
-                "tar": "^7.4.0"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
-            "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
-            "license": "ISC",
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-            "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.0.4",
-                "rimraf": "^5.0.5"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^3.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
-            "version": "5.0.10",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^10.3.7"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-            "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-            "license": "ISC",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.0.1",
-                "mkdirp": "^3.0.1",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@mapbox/point-geometry": {
@@ -4703,6 +4649,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -4715,6 +4662,7 @@
             "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -4845,7 +4793,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
             "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/archiver": {
             "version": "6.0.2",
@@ -4935,6 +4884,7 @@
             "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^3.6.0"
@@ -5691,6 +5641,7 @@
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "license": "ISC",
+            "optional": true,
             "bin": {
                 "color-support": "bin.js"
             }
@@ -5813,20 +5764,12 @@
                 "quickselect": "^2.0.0"
             }
         },
-        "node_modules/consola": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
-            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.18.0 || >=16.10.0"
-            }
-        },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
@@ -6350,7 +6293,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/density-clustering": {
             "version": "1.3.0",
@@ -6388,341 +6332,6 @@
             },
             "bin": {
                 "ignored": "bin/ignored"
-            }
-        },
-        "node_modules/duckdb": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.2.0.tgz",
-            "integrity": "sha512-zAHHRTMoZhWIwvOsyNkgV9c1nq0gR0j+ZyX0uTCRFZTNOlYO4lnErP5Fddt/6iKMXsTNL9v1oTG9E76S5jMh7w==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "@mapbox/node-pre-gyp": "^2.0.0",
-                "node-addon-api": "^7.0.0",
-                "node-gyp": "^9.3.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/@npmcli/fs": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-            "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promisify": "^1.1.3",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/@npmcli/move-file": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-            "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-            "deprecated": "This functionality has been moved to @npmcli/fs",
-            "license": "MIT",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/duckdb/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/cacache": {
-            "version": "16.1.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/cacache/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/duckdb/node_modules/cacache/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/duckdb/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/duckdb/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/duckdb/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/duckdb/node_modules/make-fetch-happen": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-            "license": "ISC",
-            "dependencies": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^16.1.0",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^2.0.3",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^9.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/duckdb/node_modules/minipass-fetch": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-            "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.1.6",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
-            }
-        },
-        "node_modules/duckdb/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/duckdb/node_modules/node-gyp": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
-            "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
-            "license": "MIT",
-            "dependencies": {
-                "env-paths": "^2.2.0",
-                "exponential-backoff": "^3.1.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^10.0.3",
-                "nopt": "^6.0.0",
-                "npmlog": "^6.0.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": "^12.13 || ^14.13 || >=16"
-            }
-        },
-        "node_modules/duckdb/node_modules/nopt": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^1.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/duckdb/node_modules/socks-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.3",
-                "socks": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/duckdb/node_modules/ssri": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-            "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.1.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/unique-filename": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-            "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/duckdb/node_modules/unique-slug": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-            "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/dunder-proto": {
@@ -6824,6 +6433,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6832,7 +6442,8 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
             "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/es-abstract": {
             "version": "1.23.9",
@@ -7301,12 +6912,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/exponential-backoff": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-            "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7685,6 +7290,7 @@
             "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
                 "color-support": "^1.1.3",
@@ -7703,7 +7309,8 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -8092,7 +7699,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/hasha": {
             "version": "5.2.2",
@@ -8153,7 +7761,8 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "optional": true
         },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
@@ -8190,6 +7799,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -8203,6 +7813,7 @@
             "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -8288,7 +7899,8 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -8356,6 +7968,7 @@
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
             "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "jsbn": "1.1.0",
                 "sprintf-js": "^1.1.3"
@@ -8368,7 +7981,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
             "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/is-arguments": {
             "version": "1.2.0",
@@ -8598,7 +8212,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
             "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -9430,6 +9045,7 @@
             "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
             "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9442,6 +9058,7 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9485,6 +9102,7 @@
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
             "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9497,6 +9115,7 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9509,6 +9128,7 @@
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9521,6 +9141,7 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9533,6 +9154,7 @@
             "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
             "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -9545,6 +9167,7 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9659,6 +9282,7 @@
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
             "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -9694,26 +9318,6 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "license": "MIT"
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/node-gyp": {
             "version": "8.4.1",
@@ -12368,6 +11972,7 @@
             "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
                 "console-control-strings": "^1.1.0",
@@ -13394,13 +12999,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
             "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "err-code": "^2.0.2",
                 "retry": "^0.12.0"
@@ -13763,6 +13370,7 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -14182,6 +13790,7 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
@@ -14192,6 +13801,7 @@
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
             "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
@@ -14304,7 +13914,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "optional": true
         },
         "node_modules/sqlite3": {
             "version": "5.1.7",
@@ -14973,12 +14584,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
-        },
         "node_modules/traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -15320,12 +14925,6 @@
                 "defaults": "^1.0.3"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/wellknown": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.5.0.tgz",
@@ -15337,16 +14936,6 @@
             },
             "bin": {
                 "wellknown": "cli.js"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -15462,6 +15051,7 @@
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
             "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }

--- a/task/package.json
+++ b/task/package.json
@@ -22,7 +22,7 @@
         "@aws-sdk/client-s3": "^3.405.0",
         "@aws-sdk/client-secrets-manager": "^3.363.0",
         "@aws-sdk/lib-storage": "^3.405.0",
-        "duckdb": "^1.2.0",
+        "@duckdb/node-api": "^1.2.0-alpha.15",
         "@openaddresses/lib": "^4.4.0",
         "@supercharge/promise-pool": "^3.0.0",
         "@turf/turf": "^6.3.0",


### PR DESCRIPTION
Follows #394 

The library added in #434 didn't work because it required a library that wasn't cross-platform compatible (arm64 vs. amd64). Trying this one instead, since it seems to be referenced on the DuckDB website (https://duckdb.org/docs/installation/?version=stable&environment=js)