### PR TITLE
Switch away from alpine linux base image

### DIFF
--- a/task/Dockerfile
+++ b/task/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.21 AS node
+FROM node:22 AS node
 FROM 847904970422.dkr.ecr.us-east-1.amazonaws.com/batch-machine:9.9.0
 
 COPY --from=node /usr/lib /usr/lib


### PR DESCRIPTION
Follows #394

My attempt at a fix in #435 failed. DuckDB is still trying to load bindings and fails in Alpine linux:

```
Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /usr/local/src/batch/node_modules/@duckdb/node-bindings-linux-x64/libduckdb.so)
    at Object..node (node:internal/modules/cjs/loader:1732:18)
    at Module.load (node:internal/modules/cjs/loader:1289:32)
    at Function._load (node:internal/modules/cjs/loader:1108:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.require (node:internal/modules/cjs/loader:1311:12)
    at require (node:internal/modules/helpers:136:16)
    at getNativeNodeBinding (/usr/local/src/batch/node_modules/@duckdb/node-bindings/duckdb.js:9:20)
    at Object.<anonymous> (/usr/local/src/batch/node_modules/@duckdb/node-bindings/duckdb.js:24:18)
    at Module._compile (node:internal/modules/cjs/loader:1554:14) {
  code: 'ERR_DLOPEN_FAILED'
```

So I'm going to try a non-Alpine linux variant of the Node Docker image.