### PR TITLE
Remove source wildcard matching

### DIFF
--- a/api/lib/types/data.js
+++ b/api/lib/types/data.js
@@ -54,7 +54,6 @@ export default class Data extends Generic {
             query.point = `POINT(${query.point.join(' ')})`;
         }
 
-        query.source = '%' + query.source + '%';
         query.layer = query.layer + '%';
         query.name = query.name + '%';
 

--- a/api/lib/types/job.js
+++ b/api/lib/types/job.js
@@ -52,7 +52,6 @@ export default class Job extends Generic {
 
         Status.verify(query.status);
 
-        query.source = '%' + query.source + '%';
         query.layer = query.layer + '%';
 
         if (query.after) {

--- a/api/lib/types/joberror.js
+++ b/api/lib/types/joberror.js
@@ -18,7 +18,6 @@ export default class JobError extends Generic {
         if (!query.status) query.status = Status.list();
 
         query.source = Params.string(query.source, { default: '' });
-        query.source = '%' + query.source + '%';
         query.layer = query.layer + '%';
 
         Status.verify(query.status);

--- a/api/lib/types/token.js
+++ b/api/lib/types/token.js
@@ -54,7 +54,6 @@ export default class Token extends Generic {
             query.point = `POINT(${query.point.join(' ')})`;
         }
 
-        query.source = '%' + query.source + '%';
         query.layer = query.layer + '%';
         query.name = query.name + '%';
 


### PR DESCRIPTION
Removes wildcards from source matching to avoid improper job selections when source names change.

I removed it from all four files containing it but I'm not totally sure that is necessary.