### PR TITLE
Optimize fabric job performance

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -197,8 +197,11 @@ export async function trigger(event) {
             containerOverrides: {
                 command: ['node', 'fabric.js'],
                 environment: [],
-                vcpus: 4,
-                memory: 15000
+                vcpus: 8,
+                memory: 58000
+            },
+            timeout: {
+                attemptDurationSeconds: 60 * 60 * 24  // 24 hour hard cap
             }
         };
     } else if (event.type === 'cleanup') {

--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -38,7 +38,7 @@ export default {
                     ],
                     Type : 'EC2',
                     InstanceRole : cf.getAtt('BatchInstanceProfile', 'Arn'),
-                    InstanceTypes : ['m5.xlarge']
+                    InstanceTypes : ['r5.2xlarge']
                 },
                 State: 'ENABLED'
             }
@@ -121,7 +121,9 @@ export default {
                         Ebs: {
                             Encrypted: true,
                             VolumeSize: 1000,
-                            VolumeType: 'gp3'
+                            VolumeType: 'gp3',
+                            Throughput: 1000,  // MB/s (max for gp3)
+                            Iops: 16000        // max for gp3
                         }
                     }]
                 }

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -251,6 +251,10 @@ async function get_source(data) {
     const key = `${process.env.StackName}/job/${data.job}/source.geojson.gz`;
     console.error(`ok - fetching ${process.env.Bucket}/${key}`);
 
+    // Write to a per-job temp file so parallel downloads don't interleave
+    // bytes into the shared layer file
+    const tmp = path.resolve(DRIVE, `${data.layer}.${data.job}.geojson`);
+
     try {
         await pipeline(
             (await s3.send(new S3.GetObjectCommand({
@@ -258,7 +262,7 @@ async function get_source(data) {
                 Key: key
             }))).Body,
             new Unzip(),
-            fs.createWriteStream(path.resolve(DRIVE, `${data.layer}.geojson`), { flags: 'a' })
+            fs.createWriteStream(tmp)
         );
     } catch (err) {
         if (err.name === 'NoSuchKey') {

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -33,6 +33,9 @@ const zooms = {
     centerlines: 8
 };
 
+// Max concurrent S3 downloads
+const DOWNLOAD_CONCURRENCY = 50;
+
 const args = minimist(process.argv, {
     boolean: ['interactive', 'fabric', 'border'],
     alias: {
@@ -140,15 +143,40 @@ async function cli() {
 
             const layers = ['addresses', 'buildings', 'parcels', 'centerlines'];
 
-            console.error(`ok - fetching ${datas.length} sources`);
-            for (const data of datas) {
+            const supported = datas.filter((data) => {
                 if (!layers.includes(data.layer)) {
                     console.error(`ok - skipping ${JSON.stringify(data)} due to unsupported layer type`);
-                    continue; // Ignore unsupported sources
+                    return false;
+                }
+                return true;
+            });
+
+            console.error(`ok - fetching ${supported.length} sources (${DOWNLOAD_CONCURRENCY} concurrent)`);
+
+            // Download each source to its own temp file in parallel (writing
+            // concurrent streams to a shared file would interleave bytes and
+            // corrupt the newline-delimited GeoJSON). Concat and delete each
+            // chunk's temp files before fetching the next chunk so peak disk
+            // usage stays at ~1x total uncompressed size rather than ~2x.
+            let completed = 0;
+            for (let i = 0; i < supported.length; i += DOWNLOAD_CONCURRENCY) {
+                const chunk = supported.slice(i, i + DOWNLOAD_CONCURRENCY);
+                await Promise.all(chunk.map((data) => get_source(data)));
+
+                for (const data of chunk) {
+                    const tmp = path.resolve(DRIVE, `${data.layer}.${data.job}.geojson`);
+                    if (!fs.existsSync(tmp)) continue;
+                    await pipeline(
+                        fs.createReadStream(tmp),
+                        fs.createWriteStream(path.resolve(DRIVE, `${data.layer}.geojson`), { flags: 'a' })
+                    );
+                    await fsp.unlink(tmp);
                 }
 
-                await get_source(data);
+                completed += chunk.length;
+                console.error(`ok - fetched ${completed}/${supported.length} sources`);
             }
+
             console.error('ok - completed fetch');
 
             for (const l of layers) {

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -27,10 +27,10 @@ const r2 = new S3.S3Client({
 });
 
 const zooms = {
-    addresses: 0,
-    parcels: 0,
-    buildings: 0,
-    centerlines: 0
+    addresses: 10,  // address points are only meaningful at street level
+    parcels: 8,
+    buildings: 10,
+    centerlines: 8
 };
 
 const args = minimist(process.argv, {

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -189,6 +189,7 @@ async function cli() {
                         std: true,
                         force: true,
                         drop: true,
+                        parallel: true,
                         name: `OpenAddresses ${l} fabric`,
                         attribution: 'OpenAddresses',
                         description: `OpenAddresses ${l} fabric`,

--- a/task/lib/tippecanoe.js
+++ b/task/lib/tippecanoe.js
@@ -31,6 +31,7 @@ export default class Tippecanoe {
      * @param {Object} options.zoom Zoom Options
      * @param {Number} options.zoom.max Max zoom of tiles
      * @param {Number} options.zoom.min Min zoom of tiles
+     * @param {Boolean} [options.parallel=false] Use multiple CPUs for tiling (-P flag)
      * @param {Boolean} options.force Delete the mbtiles file if it already exists instead of giving an error
      * @param {Object} options.limit Limit Options
      * @param {Boolean} [options.limit.features=true] Limit tiles to 200,000 features
@@ -61,6 +62,7 @@ export default class Tippecanoe {
             if (options.limit.features === false) base = base.concat(['--no-feature-limit']);
             if (options.limit.size === false) base = base.concat(['--no-tile-size-limit']);
             if (options.drop) base = base.concat(['--drop-densest-as-needed']);
+            if (options.parallel) base = base.concat(['-P']);
 
             const tippecanoe = CP.spawn('tippecanoe', base, {
                 env: process.env

--- a/task/test/cleanup.test.js
+++ b/task/test/cleanup.test.js
@@ -35,11 +35,12 @@ test('selectJobsToPrune - keeps all jobs within 3 months', (t) => {
 });
 
 test('selectJobsToPrune - keeps one per month for 3-12 months', (t) => {
-    // Two jobs in the same month, ~5 months ago
+    // Two jobs in the same month, ~5 months ago — use absolute dates so the
+    // test doesn't become flaky when relative offsets straddle a month boundary
     const jobs = [
-        makeJob(1, 1),                          // recent, active
-        makeJob(2, 150, { count: 50 }),          // ~5 months ago
-        makeJob(3, 155, { count: 60 })           // same month, ~5 months ago
+        makeJob(1, 1),
+        { id: 2, created: '2025-10-05T00:00:00Z', count: 50, size: 5000, output: { output: true } },
+        { id: 3, created: '2025-10-20T00:00:00Z', count: 60, size: 6000, output: { output: true } }
     ];
 
     const pruned = selectJobsToPrune(jobs, 1);


### PR DESCRIPTION
## Problem

The weekly OA_Fabric job has been taking 5–13 days to complete (and in one case hung silently for 7 days while burning ~$0.30/hr). Root causes:

- **Sequential S3 downloads**: 5,000+ sources fetched one at a time — pure latency waste
- **Min zoom = 0 for all layers**: forced tippecanoe to process 700M address points across 16 zoom levels. Generating drop candidates at zoom 0–9 for address points is useless (they're invisible at that scale) but accounts for the majority of tippecanoe's work
- **No `-P` flag**: tippecanoe ran single-threaded, leaving 3 of 4 vCPUs idle
- **Under-resourced instance**: `m5.xlarge` (4 vCPU / 16 GB). Tippecanoe's sort index for 700M features alone needs ~14 GB — almost certainly hitting swap
- **Default gp3 throughput (125 MB/s)**: writing and reading back 140+ GB of address GeoJSON was I/O-bound
- **No job timeout**: a hung job ran for 13 days undetected

## Changes

**Raise minimum zoom levels** — addresses and buildings start at z10 (street-level), parcels and centerlines at z8. No one needs 700M address points at a world map zoom.

**Parallelize S3 downloads** — fetch 50 sources concurrently. Each source writes to its own `{layer}.{job}.geojson` temp file (concurrent writes to a shared file would interleave bytes and corrupt the NDJSON). After each batch of 50, temp files are concatenated into the shared layer file and deleted before the next batch starts — keeping peak disk usage at ~1× total uncompressed size rather than ~2×.

**Add `-P` flag to tippecanoe** — uses all available cores for tiling.

**Bump fabric job resources** — 4 vCPU / 15 GB → 8 vCPU / 58 GB to match the new instance and give tippecanoe enough RAM to avoid swapping.

**Add 24-hour job timeout** — hard cap to prevent silent runaway jobs.

**Upgrade Mega compute environment** — `m5.xlarge` → `r5.2xlarge` (8 vCPU / 64 GB, memory-optimized). EBS throughput provisioned to max (1,000 MB/s, 16,000 IOPS) to eliminate I/O as a bottleneck.