### PR TITLE
Switch t3 compute environment to managed Spot c6a.large

### DIFF
--- a/cloudformation/cluster.template.js
+++ b/cloudformation/cluster.template.js
@@ -78,8 +78,9 @@ export default {
                 }
             },
             Properties: {
-                ImageId: 'ami-0914ebfbccd143a3f',
-                InstanceType: 't3.small',
+                ImageId: 'ami-074bb5e3c681b0735',
+                InstanceType: 'c6a.large',
+                SpotPrice: '0.0765',  // on-demand price as ceiling; pay actual spot rate
                 BlockDeviceMappings: [{
                     DeviceName: '/dev/xvda',
                     Ebs: {

--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -7,9 +7,29 @@ export default {
         BatchT3ComputeEnvironment: {
             Type: 'AWS::Batch::ComputeEnvironment',
             Properties: {
-                Type: 'UNMANAGED',
+                Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
                 ComputeEnvironmentName: 't3',
+                ComputeResources: {
+                    ImageId: 'ami-074bb5e3c681b0735',
+                    MaxvCpus: 200,
+                    MinvCpus: 0,
+                    SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
+                    Subnets: [
+                        'subnet-de35c1f5',
+                        'subnet-e67dc7ea',
+                        'subnet-38b72502',
+                        'subnet-76ae3713',
+                        'subnet-35d87242',
+                        'subnet-b978ade0'
+                    ],
+                    Type: 'SPOT',
+                    BidPercentage: 100,
+                    SpotIamFleetRole: cf.getAtt('BatchSpotFleetRole', 'Arn'),
+                    InstanceRole: cf.getAtt('BatchInstanceProfile', 'Arn'),
+                    InstanceTypes: ['c6a.large'],
+                    AllocationStrategy: 'SPOT_CAPACITY_OPTIMIZED'
+                },
                 State: 'ENABLED'
             }
         },
@@ -19,7 +39,7 @@ export default {
                 Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
                 ComputeResources: {
-                    ImageId: 'ami-0914ebfbccd143a3f',
+                    ImageId: 'ami-074bb5e3c681b0735',
                     MaxvCpus: 16,
                     DesiredvCpus: 0,
                     MinvCpus: 0,
@@ -49,7 +69,7 @@ export default {
                 Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
                 ComputeResources: {
-                    ImageId: 'ami-0914ebfbccd143a3f',
+                    ImageId: 'ami-074bb5e3c681b0735',
                     MaxvCpus: 16,
                     DesiredvCpus: 0,
                     MinvCpus: 0,
@@ -135,6 +155,23 @@ export default {
                 VpcId: 'vpc-3f2aa15a',
                 GroupDescription: 'Batch Security Group',
                 SecurityGroupIngress: []
+            }
+        },
+        BatchSpotFleetRole: {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+                AssumeRolePolicyDocument: {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Effect: 'Allow',
+                        Principal: {
+                            Service: 'spotfleet.amazonaws.com'
+                        },
+                        Action: 'sts:AssumeRole'
+                    }]
+                },
+                ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole'],
+                Path: '/'
             }
         },
         BatchServiceRole: {


### PR DESCRIPTION
## Summary

Converts the `t3` Batch compute environment from an `UNMANAGED` EC2 environment (backed by a manually-managed ASG running `t3.small` on-demand instances) to a `MANAGED SPOT` environment running `c6a.large`.

## Why

**CPU credit charges.** The `t3.small` instances were running at sustained full CPU — they are burstable instances that charge extra when they exceed their baseline. In May 2026 this showed up as $55.85/mo in `CPUCredits:t3` billing on top of the $86/mo base compute cost, for an effective rate of ~$142/mo. This is exactly the scenario where burstable instance types are the wrong choice.

**Spot is a natural fit.** The jobs running on this queue (`OA_Job_*`) are short (~13 min average), independently retryable batch tasks. Spot interruptions are handled gracefully. Current spot price for `c6a.large` is ~$0.031/hr vs $0.0765/hr on-demand.

**Memory headroom.** Each job requests 2 vCPU / 1900 MB. A `t3.small` only has 2048 MB total, leaving ~148 MB for the ECS agent — extremely tight. `c6a.large` has 4 GB, giving comfortable headroom.

## Changes

- **`task.template.js`**: `BatchT3ComputeEnvironment` converted from `UNMANAGED` → `MANAGED SPOT`
  - Instance type: `c6a.large` (2 vCPU / 4 GB, x86_64, no burstable CPU charges)
  - Allocation strategy: `SPOT_CAPACITY_OPTIMIZED`
  - `BidPercentage: 100` — pay actual spot rate, AWS caps at on-demand price automatically
  - `MaxvCpus` increased from 100 → 200 (the old ASG had `MaxSize: 100`)
  - Adds `BatchSpotFleetRole` IAM role (required for `SPOT` managed environments)
  - Updates AMI to `ami-074bb5e3c681b0735` (latest ECS-optimized AL2023, same generation as existing) on all three compute environments

- **`cluster.template.js`**: updates the launch configuration that backs the old UNMANAGED environment
  - `t3.small` → `c6a.large`
  - Adds `SpotPrice: '0.0765'` (on-demand price as ceiling)
  - Updates AMI to match

## Expected savings

| | Before | After |
|---|---|---|
| Instance type | t3.small on-demand | c6a.large Spot |
| Effective rate | ~$0.0208/hr + CPU credits | ~$0.031/hr spot, no credits |
| May 2026 cost | $141.92/mo | ~$128/mo |
| Saving | | ~$14/mo |

Note: the queue names (`t3`, `t3-priority`), ASG name (`t3-cluster-asg`), CFN export names, and application env vars (`T3_QUEUE`, `T3_PRIORITY_QUEUE`, `T3_CLUSTER_ASG`) are intentionally unchanged — renaming live resources would require a coordinated change across the API and task code.