### PR TITLE
Expand mega launch template root partition to full 500GB at boot

### DIFF
--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -123,7 +123,23 @@ export default {
                             VolumeSize: 500,
                             VolumeType: 'gp3'
                         }
-                    }]
+                    }],
+                    // Grow the root partition and filesystem to use the full 500 GB EBS volume.
+                    // Without this, the OS boots with the AMI's default ~30 GB partition layout
+                    // even though the underlying volume is 500 GB.
+                    UserData: cf.base64([
+                        'MIME-Version: 1.0\n',
+                        'Content-Type: multipart/mixed; boundary="==BOUNDARY=="\n',
+                        '\n',
+                        '--==BOUNDARY==\n',
+                        'Content-Type: text/x-shellscript; charset="us-ascii"\n',
+                        '\n',
+                        '#!/bin/bash\n',
+                        'growpart /dev/xvda 1\n',
+                        'xfs_growfs /\n',
+                        '\n',
+                        '--==BOUNDARY==--'
+                    ].join(''))
                 }
             }
         },


### PR DESCRIPTION
## Problem

The `oa_fabric` job was failing with `EPIPE` when running tippecanoe on the addresses layer. Investigation of the CloudWatch logs revealed the root cause:

```
29443885490 bytes used or committed, of 32712060928 originally available
```

Tippecanoe reported only **30.5 GB total disk** — the AMI's default 30 GB, not the 500 GB EBS volume configured in the launch template. The job was running out of disk ~2 hours into address tile generation (~5000 sources uncompressed + tippecanoe temp files), causing tippecanoe to crash, close its stdin, and Node to receive EPIPE.

## Root Cause

The `BatchMegaLaunchTemplate` correctly sets `VolumeSize: 500` in `BlockDeviceMappings`, which attaches a 500 GB EBS volume. However, AWS attaches the volume at the block device level only — the partition table and XFS filesystem on `/dev/xvda` still reflect the AMI snapshot's original 30 GB layout. Without explicitly running `growpart` and `xfs_growfs` at boot, the OS and containers only see ~30 GB.

## Fix

Add `UserData` to `BatchMegaLaunchTemplate` with a boot script that expands the partition and filesystem to use the full volume:

```bash
growpart /dev/xvda 1  # expand partition 1 to fill the 500 GB volume
xfs_growfs /          # expand the XFS filesystem to fill the partition
```

AL2023 ECS AMIs use XFS on the root partition, so `xfs_growfs` is the correct tool (not `resize2fs`). The script is delivered as a MIME multi-part `UserData` blob as recommended by the AWS Batch docs for launch template user data.