### PR TITLE
Increase mega EBS volume from 500GB to 2TB

### DIFF
--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -120,13 +120,13 @@ export default {
                         DeviceName: '/dev/xvda',
                         Ebs: {
                             Encrypted: true,
-                            VolumeSize: 500,
+                            VolumeSize: 2000,
                             VolumeType: 'gp3'
                         }
                     }],
-                    // Grow the root partition and filesystem to use the full 500 GB EBS volume.
+                    // Grow the root partition and filesystem to use the full EBS volume.
                     // Without this, the OS boots with the AMI's default ~30 GB partition layout
-                    // even though the underlying volume is 500 GB.
+                    // even though the underlying volume is larger.
                     UserData: cf.base64([
                         'MIME-Version: 1.0\n',
                         'Content-Type: multipart/mixed; boundary="==BOUNDARY=="\n',


### PR DESCRIPTION
## Problem

The `oa_fabric` job is failing with `ENOSPC` during the source download phase, at roughly 750/5083 sources. The growpart fix from #589 is working correctly — the instance does have 500 GB available — but 500 GB isn't enough.

## Analysis

Sampling 17 source jobs across the full range gave an average compressed size of ~32 MB/source. With 5083 sources and a typical GeoJSON gzip compression ratio of 5-10x:

- Estimated total **compressed**: ~160 GB
- Estimated total **uncompressed**: ~800 GB – 1.6 TB

The fabric job downloads all sources to `/tmp`, accumulating per-layer GeoJSON files (`addresses.geojson`, `buildings.geojson`, etc.) before passing them to tippecanoe. Some individual sources are very large (e.g. job 853800: 135 MB compressed, job 853101: 116 MB compressed), so the uncompressed total easily blows past 500 GB.

## Fix

Increase the mega launch template EBS volume from 500 GB to 2 TB. At the low end of the compression ratio estimate (~800 GB uncompressed) this gives comfortable headroom; even at the high end (1.6 TB) there's room for both the accumulated GeoJSON and tippecanoe's working files.

## Longer-term

A proper fix would stream sources directly into tippecanoe as they're downloaded rather than accumulating all layers to disk first, eliminating the disk scaling problem entirely. But that's a larger refactor.