### PR TITLE
Remove hardcoded ComputeEnvironmentName from BatchT3ComputeEnvironment

### DIFF
--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -9,7 +9,6 @@ export default {
             Properties: {
                 Type: 'MANAGED',
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
-                ComputeEnvironmentName: 't3',
                 ComputeResources: {
                     ImageId: 'ami-074bb5e3c681b0735',
                     MaxvCpus: 200,


### PR DESCRIPTION
CloudFormation cannot replace a custom-named resource in-place, causing `UPDATE_FAILED` when deploying `task.template.js` after #587 switched `BatchT3ComputeEnvironment` from `UNMANAGED` to `MANAGED` Spot.

Removing the hardcoded `ComputeEnvironmentName: 't3'` lets CloudFormation generate a name so it can create the new MANAGED Spot environment, update the job queues (which reference it via `cf.ref`) and then delete the old UNMANAGED one.