### PR TITLE
Reduce fabric max zoom to 14 and increase timeout to 3 days

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -201,7 +201,7 @@ export async function trigger(event) {
                 memory: 58000
             },
             timeout: {
-                attemptDurationSeconds: 60 * 60 * 24  // 24 hour hard cap
+                attemptDurationSeconds: 60 * 60 * 24 * 3  // 3 day hard cap
             }
         };
     } else if (event.type === 'cleanup') {

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -221,7 +221,7 @@ async function cli() {
                             size: false
                         },
                         zoom: {
-                            max: 15,
+                            max: 14,
                             min: zooms[l]
                         }
                     }


### PR DESCRIPTION
The addresses layer (~92GB uncompressed, 500M+ features) consistently times out at 24h when tiling single-threaded at z15. Logs show downloads take ~5h, leaving only ~19h for tippecanoe — not enough.

**Changes:**
- Drop max zoom from z15 → z14 for all fabric layers. Each z14 tile covers ~4.8km² which is still plenty of detail for address point display, and reduces tile count by 4x vs z15.
- Bump the fabric job timeout from 24h → 3 days to give headroom as the dataset grows.