### PR TITLE
Guard against OpenCollective API error responses causing 500 on profile page

### DIFF
--- a/api/lib/level.js
+++ b/api/lib/level.js
@@ -1,3 +1,4 @@
+import Err from '@openaddresses/batch-error';
 import moment from 'moment';
 import User from './user.js';
 import Override from './types/level-override.js';
@@ -84,6 +85,10 @@ export default class Level {
         });
 
         const body = await res.json();
+
+        if (!res.ok || !body.data || !body.data.account) {
+            throw new Err(500, new Error(JSON.stringify(body.errors || body)), 'OpenCollective API Error');
+        }
 
         const usrs = body.data.account.members.nodes.filter((node) => {
             return node.account.email === email;


### PR DESCRIPTION
## Problem

When a user visits their profile page, the frontend calls `GET /api/login?level=true`. This triggers `Level.single()` in `api/lib/level.js`, which makes a POST request to the OpenCollective GraphQL API.

If the OC API returns an error response (e.g. expired/missing `OPENCOLLECTIVE_API_KEY`, rate limiting, or a schema issue), the response body is `{ "errors": [...] }` instead of `{ "data": { "account": ... } }`. The code then crashes on:

```js
const usrs = body.data.account.members.nodes.filter(...)
//           ^^^^^^^^^^^ TypeError: Cannot read properties of undefined
```

This unhandled `TypeError` propagates out of the route handler and results in a 500 for the user.

## Fix

- Add `import Err from '@openaddresses/batch-error'` to `level.js`
- Guard against a bad OC API response with a check on `res.ok`, `body.data`, and `body.data.account` before accessing `.members.nodes`
- Throw a descriptive `Err` with the OC error payload so it shows up clearly in server logs

```js
if (!res.ok || !body.data || !body.data.account) {
    throw new Err(500, new Error(JSON.stringify(body.errors || body)), 'OpenCollective API Error');
}
```

**Note:** It's also worth checking that the `OPENCOLLECTIVE_API_KEY` environment variable is valid in production, as an auth failure is the most likely immediate cause of the bad OC response.