### PR TITLE
Fix null account crash in Level.single/all() causing 500 on profile page

### DIFF
--- a/api/lib/level.js
+++ b/api/lib/level.js
@@ -91,7 +91,7 @@ export default class Level {
         }
 
         const usrs = body.data.account.members.nodes.filter((node) => {
-            return node.account.email === email;
+            return node.account && node.account.email === email;
         });
 
         if (!usrs.length) return;
@@ -162,9 +162,11 @@ export default class Level {
         if (!usrs.length) return;
 
         for (const usr of usrs) {
+            // Skip nodes where account is null (OC can return null accounts for deleted users)
+            if (!usr.account) continue;
             // The user has never made a transaction
-            if (!usr.account.transactions.nodes.length) return;
-            if (!usr.account.email) return;
+            if (!usr.account.transactions.nodes.length) continue;
+            if (!usr.account.email) continue;
 
             for (const override of (await Override.list(this.pool)).level_override) {
                 if (usr.account.email.match(override.pattern)) {

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -34,7 +34,13 @@ export default async function router(schema, config) {
     }, async (req, res) => {
         if (req.auth && req.auth.username) {
             try {
-                if (req.query.level) await level.single(req.auth.email);
+                if (req.query.level) {
+                    try {
+                        await level.single(req.auth.email);
+                    } catch (err) {
+                        console.error('Failed to refresh level from OpenCollective (non-fatal):', err);
+                    }
+                }
                 res.json(await user.user(req.auth.uid));
             } catch (err) {
                 return Err.respond(err, res);

--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -66,8 +66,12 @@ export default async function router(schema, config) {
             await Auth.is_admin(req);
 
             if (req.query.level) {
-                const usr = await user.user(req.params.id);
-                await level.single(usr.email);
+                try {
+                    const usr = await user.user(req.params.id);
+                    await level.single(usr.email);
+                } catch (err) {
+                    console.error('Failed to refresh level from OpenCollective (non-fatal):', err);
+                }
             }
 
             res.json(await user.user(req.params.id));

--- a/api/test/level.srv.test.js
+++ b/api/test/level.srv.test.js
@@ -273,6 +273,175 @@ test('Level#user - no match', async () =>  {
     }
 });
 
+flight.user('test_null_account');
+
+test('Level#single - null account node does not crash', async () => {
+    // Reproduces the production crash: OC returns a node where account is null
+    // (deleted/deactivated OC account). Before the fix this threw:
+    //   TypeError: Cannot read properties of null (reading 'email')
+    nock('https://api.opencollective.com')
+        .post('/graphql/v2')
+        .reply(200, {
+            'data': {
+                'account': {
+                    'members': {
+                        'nodes': [
+                            {
+                                'id': 'null-account-node',
+                                'role': 'BACKER',
+                                'account': null
+                            },
+                            {
+                                'id': '1a47byg9-nxozdp8b-kwvpmjlv-03rek5w8',
+                                'role': 'BACKER',
+                                'account': {
+                                    'id': 'dmvrwng4-kj03dpbj-4e9qz57o-yl9e8xba',
+                                    'slug': 'test_null_account',
+                                    'transactions': {
+                                        'nodes': [
+                                            {
+                                                'createdAt': moment().subtract(10, 'days').format('YYYY-MM-DD'),
+                                                'netAmount': {
+                                                    'value': -50,
+                                                    'currency': 'USD'
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    'email': 'test_null_account@openaddresses.io'
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+    const level = new Level(flight.config.pool);
+
+    try {
+        const usr_pre = await flight.fetch('/api/login', {
+            method: 'GET',
+            auth: { bearer: flight.token.test_null_account }
+        }, true);
+
+        assert.equal(usr_pre.body.level, 'basic');
+
+        // Should not throw despite the null account node
+        await level.single('test_null_account@openaddresses.io');
+
+        const usr_post = await flight.fetch('/api/login', {
+            method: 'GET',
+            auth: { bearer: flight.token.test_null_account }
+        }, true);
+
+        // Valid node was still processed correctly
+        assert.equal(usr_post.body.level, 'backer');
+    } catch (err) {
+        assert.ifError(err, 'no errors');
+    }
+});
+
+flight.user('test_oc_error');
+
+test('Level#single - OC API error response does not crash profile page', async () => {
+    // When OC returns a non-ok response (expired key, rate limit, etc.),
+    // level.single() should throw a proper Err rather than a cryptic TypeError,
+    // and login.js wraps it so the profile page still loads.
+    nock('https://api.opencollective.com')
+        .post('/graphql/v2')
+        .reply(401, {
+            'errors': [{ 'message': 'Invalid API key' }]
+        });
+
+    const level = new Level(flight.config.pool);
+
+    // level.single() itself should throw (proper Err, not TypeError)
+    await assert.rejects(
+        () => level.single('test_oc_error@openaddresses.io'),
+        (err) => {
+            assert.ok(err.message.includes('OpenCollective API Error'), `expected OC error message, got: ${err.message}`);
+            return true;
+        }
+    );
+
+    // But the profile endpoint wraps it and should still return 200
+    const res = await flight.fetch('/api/login?level=true', {
+        method: 'GET',
+        auth: { bearer: flight.token.test_oc_error }
+    }, true);
+
+    assert.equal(res.status, 200, 'profile page should return 200 even when OC is down');
+    assert.equal(res.body.level, 'basic');
+});
+
+flight.user('test_all_null');
+
+test('Level#all - null account node is skipped, valid nodes still processed', async () => {
+    // Level.all() was using return instead of continue so a null account node
+    // would abort the entire refresh loop. Also accessing usr.account.x on null crashed.
+    nock('https://api.opencollective.com')
+        .post('/graphql/v2')
+        .reply(200, {
+            'data': {
+                'account': {
+                    'members': {
+                        'nodes': [
+                            {
+                                'id': 'null-node',
+                                'role': 'BACKER',
+                                'account': null
+                            },
+                            {
+                                'id': 'valid-node',
+                                'role': 'BACKER',
+                                'account': {
+                                    'id': 'some-id',
+                                    'slug': 'test_all_null',
+                                    'transactions': {
+                                        'nodes': [
+                                            {
+                                                'createdAt': moment().subtract(10, 'days').format('YYYY-MM-DD'),
+                                                'netAmount': {
+                                                    'value': -500,
+                                                    'currency': 'USD'
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    'email': 'test_all_null@openaddresses.io'
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+    const level = new Level(flight.config.pool);
+
+    try {
+        const usr_pre = await flight.fetch('/api/login', {
+            method: 'GET',
+            auth: { bearer: flight.token.test_all_null }
+        }, true);
+
+        assert.equal(usr_pre.body.level, 'basic');
+
+        // Should not throw, and should not abort early due to the null node
+        await level.all();
+
+        const usr_post = await flight.fetch('/api/login', {
+            method: 'GET',
+            auth: { bearer: flight.token.test_all_null }
+        }, true);
+
+        assert.equal(usr_post.body.level, 'sponsor');
+    } catch (err) {
+        assert.ifError(err, 'no errors');
+    }
+});
+
 flight.landing();
 
 test('close', () => {


### PR DESCRIPTION
## Problem

The OC GraphQL API returns member nodes where `account` is `null` (deleted/deactivated accounts). `Level.single()` was filtering with `node.account.email` without guarding for null, throwing a `TypeError` that surfaced as a 500 on `GET /api/login?level=true`.

Confirmed in CloudWatch logs (still happening after #599, most recent at 21:50 UTC Jun 19):
```
TypeError: Cannot read properties of null (reading 'email')
    at file:///home/openaddresses/api/lib/level.js:94:33
    at Array.filter
    at Level.single (file:///home/openaddresses/api/lib/level.js:93:54)
```

## Changes

### `api/lib/level.js`
- **`single()`**: add `node.account &&` null guard in the filter predicate
- **`all()`**: same null guard + fix `return` → `continue` so one null/empty node doesn't abort the entire refresh loop

### `api/routes/login.js` + `api/routes/user.js`
- Wrap `level.single()` in its own inner try/catch so any future OC error is logged but never causes a 500 on the profile or admin user-detail page

### `api/test/level.srv.test.js`
Three new tests:
- `Level#single - null account node does not crash` — mixed null + valid nodes, verifies valid node still processed
- `Level#single - OC API error response does not crash profile page` — 401 from OC still returns 200 from `/api/login`  
- `Level#all - null account node is skipped, valid nodes still processed` — null node is skipped, loop continues