### PR TITLE
Add per-source fetch timeout to collect task

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -187,6 +187,9 @@ export async function trigger(event) {
                 environment: [],
                 vcpus: 4,
                 memory: 15000
+            },
+            timeout: {
+                attemptDurationSeconds: 60 * 60 * 24  // 24 hour backstop; per-source fetches self-timeout well before this
             }
         };
     } else if (event.type === 'fabric') {

--- a/task/collect.js
+++ b/task/collect.js
@@ -156,6 +156,11 @@ async function sources(oa, tmp, datas) {
     return stats;
 }
 
+// Hard cap on a single source fetch. Without this, a stalled S3 connection
+// (no data, no error) blocks its PromisePool slot forever and the job never
+// finishes or times out - it just silently burns compute until manually killed.
+const GET_SOURCE_TIMEOUT_MS = 5 * 60 * 1000;
+
 async function get_source(oa, tmp, data, stats) {
     const dir = path.parse(data.source).dir;
     const source = `${path.parse(data.source).name}-${data.layer}-${data.name}.geojson`;
@@ -171,12 +176,15 @@ async function get_source(oa, tmp, data, stats) {
 
     console.error(`ok - fetching ${process.env.Bucket}/${process.env.StackName}/job/${data.job}/source.geojson.gz`);
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(new Error('get_source timed out')), GET_SOURCE_TIMEOUT_MS);
+
     try {
         await pipeline(
             (await s3.send(new S3.GetObjectCommand({
                 Bucket: process.env.Bucket,
                 Key: `${process.env.StackName}/job/${data.job}/source.geojson.gz`
-            }))).Body,
+            }), { abortSignal: controller.signal })).Body,
             new Unzip(),
             split(),
             new Transform({
@@ -192,6 +200,8 @@ async function get_source(oa, tmp, data, stats) {
         console.error(err);
         console.error('not ok - ' + path.resolve(tmp, 'sources', dir, source));
         throw err;
+    } finally {
+        clearTimeout(timeout);
     }
 
     console.error('ok - ' + path.resolve(tmp, 'sources',  dir, source));


### PR DESCRIPTION
## Summary
- OA_Collect was found stuck RUNNING for 60+ hours with 0% CPU and no logs since the first ~1hr of the run - a stalled S3 connection in `get_source` had nothing to time it out, so it blocked its `PromisePool` slot forever.
- Wraps each source fetch in an `AbortController` watchdog (5min) so a stalled connection throws instead of hanging - the error then flows into the retry loop that already existed in `sources()`.
- Adds a 24h `attemptDurationSeconds` backstop on the job itself in case something outside `get_source` stalls (e.g. the final zip upload).

## Test plan
- [x] Verified via CloudWatch that the hung job had 0% CPU and no log output for 50+ hours (confirmed genuinely stuck, not just slow)
- [x] Terminated the stuck job in prod
- [ ] Confirm next scheduled collect run completes normally with the fix deployed