### PR TITLE
Tile smaller fabric layers before addresses

### DIFF
--- a/task/fabric.js
+++ b/task/fabric.js
@@ -154,7 +154,10 @@ async function cli() {
             // Build Data Fabric
             const datas = await oa.cmd('data', 'list');
 
-            const layers = ['addresses', 'buildings', 'parcels', 'centerlines'];
+            // Smallest/fastest layers first: addresses is ~92GB uncompressed and can
+            // eat the whole 3-day attempt timeout on its own. Tiling it last means a
+            // timeout there still ships the other three layers instead of nothing.
+            const layers = ['centerlines', 'parcels', 'buildings', 'addresses'];
 
             const supported = datas.filter((data) => {
                 if (!layers.includes(data.layer)) {


### PR DESCRIPTION
## Summary
- The `addresses` layer is ~92GB uncompressed and can eat the entire 3-day attempt timeout on its own (confirmed happening in prod this week).
- Layers were processed in order `['addresses', 'buildings', 'parcels', 'centerlines']`, so a timeout on addresses means nothing ships that week - not even the three much smaller layers that would have finished fine.
- Reorders to `['centerlines', 'parcels', 'buildings', 'addresses']` so a timeout on the last (biggest) layer still leaves 3 fresh layers published instead of zero.
- Pure mitigation, not a fix - see the companion sharded-tiling PR for the actual throughput fix.

## Test plan
- [x] Syntax-checked
- [ ] Confirm next fabric run publishes centerlines/parcels/buildings even if addresses still times out