### PR TITLE
Shard fabric tiling across vCPUs to fix addresses timeout

### DIFF
--- a/task/fabric.js
+++ b/task/fabric.js
@@ -6,6 +6,7 @@ const DRIVE = '/tmp';
 
 import fs from 'fs';
 import fsp from 'fs/promises';
+import os from 'os';
 import { pipeline } from 'stream/promises';
 import { Transform } from 'stream';
 import path from 'path';
@@ -166,6 +167,67 @@ async function cli() {
 
             console.error(`ok - fetching ${supported.length} sources (${DOWNLOAD_CONCURRENCY} concurrent)`);
 
+            // Tippecanoe's -P flag only parallelizes reading input, not the tiling/
+            // indexing pass itself - a single tippecanoe process only ever uses one
+            // core no matter how big the box is. To actually use the rest of the
+            // vCPUs, split each layer's sources across SHARD_COUNT files, tile them
+            // as separate tippecanoe processes running concurrently, then merge the
+            // resulting tilesets with tile-join.
+            //
+            // Shards MUST be geographic, not just size-balanced: tile-join has no
+            // flag to disable its own tile size/feature cap (confirmed empirically -
+            // it rejects --no-feature-limit/--no-tile-size-limit outright as unknown
+            // options), so if two shards both have data in the same dense tile (e.g.
+            // a city split across shards by pure byte-size balancing), tile-join
+            // silently truncates the merged tile to its default cap. In testing, two
+            // shards with ~250k features each in the same tile joined down to just
+            // ~80k - an 84% loss with no error or warning.
+            //
+            // Grouping by each source's path prefix (e.g. "us/tx", "mx") and
+            // bin-packing whole groups across shards means no two shards ever hold
+            // data for the same country/state, so tile-join only ever concatenates
+            // disjoint tilesets - its actual intended use case. The prefix doesn't
+            // always exactly match a source's real geographic extent, but it
+            // eliminates the failure mode that matters: dense city-center clusters,
+            // which live within a single source's prefix. Remaining cross-shard
+            // overlap is limited to sparse, low-density cross-border slivers.
+            const SHARD_COUNT = os.cpus().length;
+
+            function assignShards(sources) {
+                const groups = new Map();
+                for (const data of sources) {
+                    const key = path.parse(data.source).dir || data.source;
+                    if (!groups.has(key)) groups.set(key, { size: 0, jobs: [] });
+                    const group = groups.get(key);
+                    group.size += data.size || 0;
+                    group.jobs.push(data.job);
+                }
+
+                // Greedily bin-pack groups (largest first) onto whichever shard
+                // currently has the least total size. Every assignment bumps the
+                // chosen shard's tracked size by at least 1 so groups with unknown
+                // (null) size still round-robin instead of piling onto shard 0.
+                const sorted = [...groups.values()].sort((a, b) => b.size - a.size);
+                const shardSizes = new Array(SHARD_COUNT).fill(0);
+                const jobShard = new Map();
+                for (const group of sorted) {
+                    let idx = 0;
+                    for (let i = 1; i < shardSizes.length; i++) {
+                        if (shardSizes[i] < shardSizes[idx]) idx = i;
+                    }
+                    shardSizes[idx] += Math.max(group.size, 1);
+                    for (const job of group.jobs) jobShard.set(job, idx);
+                }
+                return jobShard;
+            }
+
+            const jobShard = new Map();
+            for (const l of layers) {
+                for (const [job, shard] of assignShards(supported.filter((data) => data.layer === l))) {
+                    jobShard.set(job, shard);
+                }
+            }
+
             // Download each source to its own temp file in parallel (writing
             // concurrent streams to a shared file would interleave bytes and
             // corrupt the newline-delimited GeoJSON). Overlap the concat/delete
@@ -187,9 +249,10 @@ async function cli() {
                     for (const data of chunk) {
                         const tmp = path.resolve(DRIVE, `${data.layer}.${data.job}.geojson`);
                         if (!fs.existsSync(tmp)) continue;
+                        const shard = jobShard.get(data.job);
                         await pipeline(
                             fs.createReadStream(tmp),
-                            fs.createWriteStream(path.resolve(DRIVE, `${data.layer}.geojson`), { flags: 'a' })
+                            fs.createWriteStream(path.resolve(DRIVE, `${data.layer}.shard${shard}.geojson`), { flags: 'a' })
                         );
                         await fsp.unlink(tmp);
                     }
@@ -204,28 +267,57 @@ async function cli() {
             console.error('ok - completed fetch');
 
             for (const l of layers) {
-                console.error(`ok - generating ${l} tiles`);
-                await tippecanoe.tile(
-                    fs.createReadStream(path.resolve(DRIVE, `${l}.geojson`)),
-                    path.resolve(DRIVE, `${l}.pmtiles`),
-                    {
-                        layer: l,
-                        std: true,
-                        force: true,
-                        drop: true,
-                        name: `OpenAddresses ${l} fabric`,
-                        attribution: 'OpenAddresses',
-                        description: `OpenAddresses ${l} fabric`,
-                        limit: {
-                            features: false,
-                            size: false
-                        },
-                        zoom: {
-                            max: 14,
-                            min: zooms[l]
-                        }
+                const shardInputs = [];
+                for (let i = 0; i < SHARD_COUNT; i++) {
+                    const shardInput = path.resolve(DRIVE, `${l}.shard${i}.geojson`);
+                    if (fs.existsSync(shardInput)) shardInputs.push({ index: i, file: shardInput });
+                }
+
+                if (!shardInputs.length) throw new Error(`no sources found for layer ${l}`);
+
+                console.error(`ok - generating ${l} tiles (${shardInputs.length} shard${shardInputs.length === 1 ? '' : 's'})`);
+
+                const tileOptions = {
+                    layer: l,
+                    std: true,
+                    force: true,
+                    drop: true,
+                    name: `OpenAddresses ${l} fabric`,
+                    attribution: 'OpenAddresses',
+                    description: `OpenAddresses ${l} fabric`,
+                    limit: {
+                        features: false,
+                        size: false
+                    },
+                    zoom: {
+                        max: 14,
+                        min: zooms[l]
                     }
-                );
+                };
+
+                // Tile each shard concurrently - this is what actually uses the
+                // box's other vCPUs, since a single tippecanoe process can't.
+                await Promise.all(shardInputs.map(({ index, file }) =>
+                    tippecanoe.tile(
+                        fs.createReadStream(file),
+                        path.resolve(DRIVE, `${l}.shard${index}.pmtiles`),
+                        tileOptions
+                    )
+                ));
+
+                const shardOutputs = shardInputs.map(({ index }) => path.resolve(DRIVE, `${l}.shard${index}.pmtiles`));
+
+                if (shardOutputs.length === 1) {
+                    await fsp.rename(shardOutputs[0], path.resolve(DRIVE, `${l}.pmtiles`));
+                } else {
+                    console.error(`ok - joining ${shardOutputs.length} ${l} shards`);
+                    await tippecanoe.join(
+                        path.resolve(DRIVE, `${l}.pmtiles`),
+                        shardOutputs,
+                        { force: true, std: true }
+                    );
+                    await Promise.all(shardOutputs.map((p) => fsp.unlink(p)));
+                }
 
                 // Upload individual layer PMTiles to S3
                 const s3Upload = new Upload({
@@ -254,7 +346,7 @@ async function cli() {
                 await r2Upload.done();
                 console.error(`ok - uploaded ${l}.pmtiles to S3 and R2`);
 
-                await fsp.unlink(path.resolve(DRIVE, `${l}.geojson`));
+                await Promise.all(shardInputs.map(({ file }) => fsp.unlink(file)));
                 await fsp.unlink(path.resolve(DRIVE, `${l}.pmtiles`));
                 console.error(`ok - cleaned up ${l} temp files`);
             }

--- a/task/lib/tippecanoe.js
+++ b/task/lib/tippecanoe.js
@@ -97,14 +97,18 @@ export default class Tippecanoe {
     /**
      * Join multiple MBTiles into a single MBTiles
      *
+     * Note: unlike tippecanoe itself, tile-join has no flag to disable its own
+     * tile size/feature cap - passing --no-feature-limit/--no-tile-size-limit
+     * to it fails with "unrecognized option". Inputs that overlap in the same
+     * tile (e.g. from geographically-overlapping shards) will get silently
+     * capped on merge, so callers must ensure inputs don't share tiles for the
+     * same layer.
+     *
      * @param {String} output_path Path to input MBTiles
      * @param {String[]} inputs Array of paths to input MBTiles
      * @param {Object} options Optional Options
      * @param {boolean} options.std Don't squelch tippecanoe stderr/stdout [default: false]
      * @param {Boolean} options.force Delete the mbtiles file if it already exists instead of giving an error
-     * @param {Object} options.limit Limit Options
-     * @param {Boolean} [options.limit.features=true] Limit tiles to 200,000 features
-     * @param {Boolean} [options.limit.size=true] Limit tiles to 500K bytes
      *
      * @returns {Promise}
      */
@@ -118,8 +122,6 @@ export default class Tippecanoe {
             ].concat(inputs);
 
             if (options.force) base = base.concat(['-f']);
-            if (options.limit.features === false) base = base.concat(['--no-feature-limit']);
-            if (options.limit.size === false) base = base.concat(['--no-tile-size-limit']);
 
             const tilejoin = CP.spawn('tile-join', base, {
                 env: process.env


### PR DESCRIPTION
## Summary
- OA_Fabric has been timing out at its 3-day attempt cap while tiling the `addresses` layer. CloudWatch confirms the instance sustains ~96% CPU throughout - it's not stuck, it's genuinely CPU-bound.
- Tippecanoe's `-P` flag only parallelizes *reading* input, not the tiling/indexing pass itself, so a single `tippecanoe` invocation only ever uses one core regardless of instance size - the r5.2xlarge's other 7 vCPUs sit idle during the actual bottleneck.
- This splits each layer's sources across `SHARD_COUNT` (= vCPU count) files, tiles each shard as a separate concurrent `tippecanoe` process, then merges the results with `tile-join`.
- **Shards are grouped by source path prefix (e.g. `us/tx`, `mx`), not raw byte size.** `tile-join` has no flag to disable its own tile size/feature cap (`--no-feature-limit`/`--no-tile-size-limit` are rejected outright as unrecognized options), so if two shards both hold data in the same dense tile, the merge silently truncates to tile-join's default cap. Verified locally: two shards with ~250k features each in the same tile joined down to ~80k - an 84% loss with no error. Grouping whole geographic prefixes onto one shard each means no two shards ever contend for the same city's tiles, so tile-join is only ever concatenating disjoint tilesets (its actual intended use). This isn't a perfect partition (a prefix doesn't always exactly match a source's real extent), but it eliminates the failure mode that matters - remaining cross-shard overlap is limited to sparse, low-density cross-border slivers.
- Also fixes a latent bug in `Tippecanoe.join()`: it dereferenced `options.limit` without defaulting it (would throw if called without explicit `limit`), and removes the `--no-feature-limit`/`--no-tile-size-limit` passthrough entirely since tile-join doesn't support those flags.

## Testing done
Validated locally against the real `tippecanoe`/`tile-join` binaries (not just reasoning about flags):
1. Confirmed byte-size-only sharding is unsafe: two shards with a dense, geographically-overlapping cluster joined to ~80k features vs. ~500k tiling the same data in one pass (84% loss).
2. Confirmed geographic-prefix sharding fixes it: 3 dense "cities" + 5 filler regions, bin-packed across 3 shards by prefix, tiled separately and joined - result was 597,094 features vs. 597,101 tiling directly in one pass (0.001% difference, within normal algorithmic noise).
3. Exercised the actual `Tippecanoe.tile()`/`join()` class methods (not just the CLI) end-to-end against synthetic overlapping shards to confirm the wrapper code path works.

## Test plan
- [x] Local validation against real tippecanoe/tile-join binaries (see above)
- [x] Syntax-checked
- [ ] Dry-run against a real week's `addresses` source set before relying on it for the production schedule
- [ ] Confirm wall-clock improvement on the next scheduled fabric run