### PR TITLE
Schedule weekly cleanup cron job

### DIFF
--- a/cloudformation/batch.template.js
+++ b/cloudformation/batch.template.js
@@ -234,5 +234,6 @@ export default cf.merge(
     schedule('collect', 'cron(0 12 ? * sun *)', 'Collection Rebuild'),
     schedule('fabric',  'cron(0 18 ? * sun *)', 'Rebuild Border & Fabric Tiles'),
     schedule('level',   'cron(0 10 * * ? *)', 'Ensure all accounts have proper levels'),
-    schedule('close',   'cron(0 11 * * ? *)', 'Close Expired Jobs')
+    schedule('close',   'cron(0 11 * * ? *)', 'Close Expired Jobs'),
+    schedule('cleanup', 'cron(0 12 ? * wed *)', 'Cleanup Old Runs')
 );


### PR DESCRIPTION
## Summary
- Adds the `schedule('cleanup', 'cron(0 12 ? * wed *)', 'Cleanup Old Runs')` CloudFormation cron entry that was deferred as a manual-validation follow-up when the cleanup task itself was built and merged (#561-#587).
- `task/cleanup.js` and its API routes (`cleanup` event type in `api/lib/schedule.js` / `api/lib/batch.js`) are already in place and merged to master — this was the only missing piece to actually run it in production.

## Why
Investigating the AWS cost increase over the last few months, this task appears to have never run: no `OA_Cleanup` job shows up in recent AWS Batch history, and there's no cron wiring it up. Scheduling it should start reclaiming S3/R2/DB storage per the retention policy already implemented.

## Test plan
- [ ] Deploy to prod
- [ ] Confirm `OA_Cleanup` job runs on the next Wednesday 12:00 UTC trigger
- [ ] Review its dry-run-free output/stats in CloudWatch logs