### PR TITLE
Give T3 spot fleet its own launch template with a real disk size

### DIFF
--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -14,6 +14,10 @@ export default {
                     MaxvCpus: 200,
                     MinvCpus: 0,
                     SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
+                    LaunchTemplate: {
+                        LaunchTemplateId: cf.ref('BatchT3LaunchTemplate'),
+                        Version: cf.getAtt('BatchT3LaunchTemplate', 'LatestVersionNumber')
+                    },
                     Subnets: [
                         'subnet-de35c1f5',
                         'subnet-e67dc7ea',
@@ -114,6 +118,37 @@ export default {
             Properties: {
                 Roles: [cf.ref('BatchInstanceRole')],
                 Path: '/'
+            }
+        },
+        BatchT3LaunchTemplate: {
+            Type: 'AWS::EC2::LaunchTemplate',
+            Properties: {
+                LaunchTemplateData: {
+                    BlockDeviceMappings: [{
+                        DeviceName: '/dev/xvda',
+                        Ebs: {
+                            Encrypted: true,
+                            VolumeSize: 100,
+                            VolumeType: 'gp3'
+                        }
+                    }],
+                    // Grow the root partition and filesystem to use the full EBS volume.
+                    // Without this, the OS boots with the AMI's default ~30 GB partition layout
+                    // even though the underlying volume is larger.
+                    UserData: cf.base64([
+                        'MIME-Version: 1.0\n',
+                        'Content-Type: multipart/mixed; boundary="==BOUNDARY=="\n',
+                        '\n',
+                        '--==BOUNDARY==\n',
+                        'Content-Type: text/x-shellscript; charset="us-ascii"\n',
+                        '\n',
+                        '#!/bin/bash\n',
+                        'growpart /dev/xvda 1\n',
+                        'xfs_growfs /\n',
+                        '\n',
+                        '--==BOUNDARY==--'
+                    ].join(''))
+                }
             }
         },
         BatchLargeLaunchTemplate: {

--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -124,11 +124,16 @@ export default {
             Type: 'AWS::EC2::LaunchTemplate',
             Properties: {
                 LaunchTemplateData: {
+                    // Most single-source jobs need well under 1GB (see #613/#615
+                    // discussion) - this is modest headroom over the AMI's bare
+                    // ~30GB default, not sized for outliers. Sources that need
+                    // more should be tagged conform.size:"large" and routed to
+                    // the `large` queue (#615) instead of bumping this for everyone.
                     BlockDeviceMappings: [{
                         DeviceName: '/dev/xvda',
                         Ebs: {
                             Encrypted: true,
-                            VolumeSize: 100,
+                            VolumeSize: 40,
                             VolumeType: 'gp3'
                         }
                     }],


### PR DESCRIPTION
## Summary
- Adds `BatchT3LaunchTemplate` (40GB gp3, with the same growpart/xfs_growfs boot script `BatchMegaLaunchTemplate` already uses) and wires it into `BatchT3ComputeEnvironment`.

## Why
Investigating AWS costs and the "large datasets like NAD" comment from `abf26db`, I found that commit's 500GB volume bump landed on `cloudformation/cluster.template.js`'s standalone `T3ClusterASG` — a resource that, per `2912f0f` (2026-06-07, "Switch t3 compute environment to managed Spot c6a.large"), stopped being what actually runs `t3`-queue jobs. That migration converted `BatchT3ComputeEnvironment` from `UNMANAGED` (backed by the ASG's own instances) to `MANAGED`/`SPOT`, and the new `ComputeResources` block never got a `LaunchTemplate`/`BlockDeviceMappings` override like `mega`/`large` have — so it's been running on the bare AMI's default 30GB volume ever since, while the 500GB ASG sits unused (scaled to 0, kept around for PR checks per @iandees).

Consequence: `sources/us/countrywide.json` (NAD) has failed on every attempt for over a year, including all attempts after the March fix. Most recent failure (2026-07-31, job 882765): `OSError: [Errno 28] No space left on device` after ~19 min, having written ~22GB — consistent with the real 30GB default, not 500GB.

**Revised from the original 100GB**: across all 5,089 currently-successful sources, the largest output is ~1.5GB and only 3 exceed 1GB - almost nothing needs more than a lean default. #615 adds a `large` job queue plus an explicit `conform.size:"large"` opt-in (companion schema PR: openaddresses/openaddresses#8260) so the rare true outlier (NAD) gets routed to a bigger volume instead of every job paying for headroom it doesn't need. This PR now just gives T3 a sane *default* (40GB - modest headroom over the bare 30GB minimum) instead of the AMI default it's been silently stuck on.

## Out of scope
- Not touching `cluster.template.js`'s `T3ClusterASG` — still used for PR checks, just idle.
- Not touching `api/lib/batch.js`'s `scale_in`/`scale_out`/`clear_stale_protection`, which still reference `T3_CLUSTER_ASG` directly — that needs its own pass if/when the old ASG is ever retired.
- Routing large sources elsewhere is handled in #615, not here.

## Test plan
- [ ] Deploy to prod
- [ ] Confirm new `t3`-queue instances launch with a 40GB root volume
- [ ] After #615 and openaddresses/openaddresses#8260 are also deployed, re-run the NAD (`us/countrywide`) job and confirm it lands on the `large` queue and gets further than the previous ENOSPC failure