### PR TITLE
Submit each fabric layer as its own Batch job with its own timeout

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -9,6 +9,24 @@ const t3_queue = process.env.T3_QUEUE;
 const t3_priority_queue = process.env.T3_PRIORITY_QUEUE;
 const mega_queue = process.env.MEGA_QUEUE;
 
+const FABRIC_LAYERS = ['addresses', 'buildings', 'parcels', 'centerlines'];
+
+async function submit(params) {
+    const res = await batch.send(new Batch.SubmitJobCommand(params));
+    console.log(`Job ${res.jobName} launched with id ${res.jobId}`);
+    return res;
+}
+
+async function afterSubmit() {
+    try {
+        // Scaling should never block the Queue
+        await scale_out();
+    } catch (err) {
+        console.error(err);
+        console.error('not ok - Failed to scale out ASG');
+    }
+}
+
 /**
  * Scale Batch T3 ASG Cluster up to MaxSize as needed
  */
@@ -190,20 +208,36 @@ export async function trigger(event) {
             }
         };
     } else if (event.type === 'fabric') {
-        params = {
-            jobDefinition: jobDefinition,
-            jobQueue: mega_queue,
-            jobName: 'OA_Fabric',
-            containerOverrides: {
-                command: ['node', 'fabric.js'],
-                environment: [],
-                vcpus: 8,
-                memory: 58000
-            },
-            timeout: {
-                attemptDurationSeconds: 60 * 60 * 24 * 3  // 3 day hard cap
-            }
-        };
+        // Each layer (plus borders) is submitted as its own job with its own
+        // 3-day budget, so a slow/stuck layer (e.g. addresses, by far the
+        // largest) can't starve the others out of the week entirely - they
+        // used to all share one job and one timeout, processed sequentially.
+        const fabricJobs = [
+            { name: 'Border', args: ['--border'] },
+            ...FABRIC_LAYERS.map((layer) => ({
+                name: layer.charAt(0).toUpperCase() + layer.slice(1),
+                args: ['--fabric', '--layer', layer]
+            }))
+        ];
+
+        for (const job of fabricJobs) {
+            await submit({
+                jobDefinition: jobDefinition,
+                jobQueue: mega_queue,
+                jobName: `OA_Fabric_${job.name}`,
+                containerOverrides: {
+                    command: ['node', 'fabric.js', ...job.args],
+                    environment: [],
+                    vcpus: 8,
+                    memory: 58000
+                },
+                timeout: {
+                    attemptDurationSeconds: 60 * 60 * 24 * 3  // 3 day hard cap, per layer
+                }
+            });
+        }
+
+        return await afterSubmit();
     } else if (event.type === 'cleanup') {
         params = {
             jobDefinition: jobDefinition,
@@ -228,15 +262,7 @@ export async function trigger(event) {
         throw new Error('Unknown event type: ' + event.type);
     }
 
-    const res = await batch.send(new Batch.SubmitJobCommand(params));
+    await submit(params);
 
-    console.log(`Job ${res.jobName} launched with id ${res.jobId}`);
-
-    try {
-        // Scaling should never block the Queue
-        await scale_out();
-    } catch (err) {
-        console.error(err);
-        console.error('not ok - Failed to scale out ASG');
-    }
+    return await afterSubmit();
 }

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -51,6 +51,7 @@ const DOWNLOAD_CONCURRENCY = 200;
 
 const args = minimist(process.argv, {
     boolean: ['interactive', 'fabric', 'border'],
+    string: ['layer'],
     alias: {
         interactive: 'i'
     }
@@ -154,7 +155,13 @@ async function cli() {
             // Build Data Fabric
             const datas = await oa.cmd('data', 'list');
 
-            const layers = ['addresses', 'buildings', 'parcels', 'centerlines'];
+            // Each layer is submitted as its own Batch job (see api/lib/batch.js)
+            // so a slow layer can't eat the other layers' timeout budget. --layer
+            // restricts this run to a single layer; with no --layer, all four run
+            // in this one process (used for local/manual runs).
+            const ALL_LAYERS = ['addresses', 'buildings', 'parcels', 'centerlines'];
+            const layers = args.layer ? ALL_LAYERS.filter((l) => l === args.layer) : ALL_LAYERS;
+            if (args.layer && layers.length === 0) throw new Error(`unknown --layer: ${args.layer}`);
 
             const supported = datas.filter((data) => {
                 if (!layers.includes(data.layer)) {


### PR DESCRIPTION
## Summary
- `task/fabric.js`: adds a `--layer <name>` flag that restricts a run to a single layer (addresses/buildings/parcels/centerlines). No flag = all four, same as before (used for local/manual runs).
- `api/lib/batch.js`: the `fabric` schedule trigger now submits 5 separate Batch jobs (`OA_Fabric_Border`, `OA_Fabric_Addresses`, `OA_Fabric_Buildings`, `OA_Fabric_Parcels`, `OA_Fabric_Centerlines`) instead of one `OA_Fabric` job, each with its own independent 3-day timeout.

## Why
Investigated why the weekly fabric job is never successful (AWS cost review). Found: `task/fabric.js` processed the four layers sequentially in one job sharing one 3-day timeout. CloudWatch CPU data for the most recent run (2026-07-26) shows tippecanoe genuinely working, not hung — sustained 90-95%+ CPU for ~44 of the ~72 hours — it's just legitimately too slow to finish `addresses` (by far the largest layer, processed first) within the budget. Because the loop is sequential, `buildings`/`parcels`/`centerlines` never even start most weeks — the whole 3-day budget goes to `addresses` alone, every time.

Splitting into independent per-layer jobs means a slow/stuck `addresses` run can no longer prevent the other three layers from getting their own full 3-day attempt. `mega` queue's `MaxvCpus: 16` (2 concurrent r5.2xlarge jobs) means these run 2-at-a-time rather than serially, which should also shorten total wall-clock versus before.

Border generation is unchanged in cost/behavior, just now its own job (`--border`) instead of always bundled into the same process as layer 1.

## Out of scope
- Not touching shard balancing within a single layer's tiling (the addresses-layer imbalance noted in investigation) — that's a separate, smaller optimization on top of this.
- Job resource sizing (8 vCPU / 58GB) is unchanged and applied uniformly across all 5 jobs, including the much smaller border job, to keep this change minimal — can be tuned down later with real per-layer usage data.

## Test plan
- [ ] `npm test` in `task/` (65/65 passing locally, unaffected by this change)
- [ ] Deploy to prod
- [ ] Confirm all 5 `OA_Fabric_*` jobs get submitted on the next Sunday 18:00 UTC trigger
- [ ] Confirm buildings/parcels/centerlines actually complete for the first time in recent history