### PR TITLE
Wire up a large-disk job queue and route oversized sources to it

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -8,6 +8,31 @@ const jobDefinition = process.env.JOB_DEFINITION;
 const t3_queue = process.env.T3_QUEUE;
 const t3_priority_queue = process.env.T3_PRIORITY_QUEUE;
 const mega_queue = process.env.MEGA_QUEUE;
+const large_queue = process.env.LARGE_QUEUE;
+
+/**
+ * Look up a source's conform.size tag (see CONTRIBUTING.md in the sources
+ * repo) to decide whether a job needs the large-disk queue. Fails open to
+ * 'standard' - a source we can't check should behave like every source did
+ * before this existed, not block submission.
+ *
+ * @param {Object} event Same event passed to trigger()
+ */
+async function sourceSizeTier(event) {
+    try {
+        const res = await fetch(event.source);
+        if (!res.ok) return 'standard';
+
+        const src = await res.json();
+        const entries = (src.layers && src.layers[event.layer]) || [];
+        const entry = entries.find((e) => e.name === event.name);
+
+        return entry?.conform?.size === 'large' ? 'large' : 'standard';
+    } catch (err) {
+        console.error('not ok - failed to check source size tier, defaulting to standard:', err.message);
+        return 'standard';
+    }
+}
 
 /**
  * Scale Batch T3 ASG Cluster up to MaxSize as needed
@@ -146,9 +171,15 @@ export async function trigger(event) {
         if (!event.layer) throw new Error('Layer of source required');
         if (!event.name) throw new Error('Name of source layer required');
 
+        // A source tagged conform.size:"large" (e.g. NAD) always goes to the
+        // large-disk queue, regardless of job vs job-ci - correctness over
+        // the job-ci fast lane for this rare case.
+        const tier = await sourceSizeTier(event);
+        const queue = tier === 'large' ? large_queue : (event.type === 'job' ? t3_queue : t3_priority_queue);
+
         params = {
             jobDefinition: jobDefinition,
-            jobQueue: event.type === 'job' ? t3_queue : t3_priority_queue,
+            jobQueue: queue,
             jobName: `OA_Job_${event.job}`,
             containerOverrides: {
                 command: ['node', 'task.js'],

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -233,6 +233,7 @@ export default {
                         { Name: 'T3_PRIORITY_QUEUE', Value:  cf.importValue('t3-priority-queue') },
                         { Name: 'T3_CLUSTER_ASG', Value: cf.importValue('t3-cluster-asg') },
                         { Name: 'MEGA_QUEUE', Value: cf.importValue('mega-queue') },
+                        { Name: 'LARGE_QUEUE', Value: cf.importValue('large-queue') },
                         { Name: 'ECS_LOG_LEVEL', Value: 'debug' },
                         { Name: 'PROTOMAPS_KEY', Value: cf.ref('ProtomapsKey') },
                         { Name: 'OPENCOLLECTIVE_API_KEY', Value: cf.ref('OpenCollective') },

--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -127,7 +127,23 @@ export default {
                             VolumeSize: 250,
                             VolumeType: 'gp3'
                         }
-                    }]
+                    }],
+                    // Grow the root partition and filesystem to use the full EBS volume.
+                    // Without this, the OS boots with the AMI's default ~30 GB partition layout
+                    // even though the underlying volume is larger.
+                    UserData: cf.base64([
+                        'MIME-Version: 1.0\n',
+                        'Content-Type: multipart/mixed; boundary="==BOUNDARY=="\n',
+                        '\n',
+                        '--==BOUNDARY==\n',
+                        'Content-Type: text/x-shellscript; charset="us-ascii"\n',
+                        '\n',
+                        '#!/bin/bash\n',
+                        'growpart /dev/xvda 1\n',
+                        'xfs_growfs /\n',
+                        '\n',
+                        '--==BOUNDARY==--'
+                    ].join(''))
                 }
             }
         },
@@ -239,6 +255,18 @@ export default {
                 Priority: 2,
                 JobQueueName: 't3-priority'
             }
+        },
+        BatchLargeJobQueue: {
+            Type: 'AWS::Batch::JobQueue',
+            Properties: {
+                ComputeEnvironmentOrder: [{
+                    Order: 1,
+                    ComputeEnvironment: cf.ref('BatchLargeComputeEnvironment')
+                }],
+                State: 'ENABLED',
+                Priority: 1,
+                JobQueueName: 'large'
+            }
         }
     },
     Outputs: {
@@ -261,6 +289,13 @@ export default {
             Value: cf.ref('BatchMegaJobQueue'),
             Export: {
                 Name: 'mega-queue'
+            }
+        },
+        LargeQueue: {
+            Description: 'Large Queue',
+            Value: cf.ref('BatchLargeJobQueue'),
+            Export: {
+                Name: 'large-queue'
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds a `large` Batch job queue (`BatchLargeJobQueue`) pointing at the previously-unused `BatchLargeComputeEnvironment` (`m5.large`/`c5.large`, 250GB gp3).
- Fixes `BatchLargeLaunchTemplate` to include the growpart/xfs_growfs boot script - without it the OS would only see the AMI's default ~30GB partition regardless of the 250GB EBS device, same gap #613 fixed for the T3 fleet.
- Wires `LARGE_QUEUE` through to the API task's environment (`cloudformation/lib/api.js`), matching the existing `T3_QUEUE`/`MEGA_QUEUE` pattern.
- `api/lib/batch.js`: for `job`/`job-ci` submissions, fetches the source JSON and checks the matching layer/name entry's `conform.size` tag. `size: "large"` routes to the `large` queue instead of `t3`/`t3-priority`; anything else (including sources with no `size` set, or any fetch/parse failure) keeps today's behavior. Fails open to `standard` on any error - a source we can't check shouldn't get its submission blocked.

## Why
Follow-up to #613. That PR fixed T3's disk from the bare AMI's 30GB default up to 100GB - but every source pays for that, when the ~1.5GB max output across all 5,089 currently-successful sources shows almost none of them need it. This PR is the other half: shrink T3 back down to a lean default (#613 will be revised) and give only the small number of genuinely oversized sources (e.g. NAD) a bigger volume via a separate queue, selected by an explicit opt-in field (`conform.size`) rather than guessing from source size (which doesn't work for NAD - it's never once succeeded, so it has no recorded output size to detect).

Companion PR in the sources repo: openaddresses/openaddresses#8260 (adds the `conform.size` schema field, sets it on `sources/us/countrywide.json`).

## Test plan
- [ ] Both CloudFormation templates load/compile cleanly and cross-reference correctly (verified locally)
- [ ] `sourceSizeTier()` tested end-to-end against real GitHub content: NAD (`sources/us/countrywide.json` on the companion PR's branch) → `large`; a normal source → `standard`; a 404 → fails open to `standard` (all verified locally)
- [ ] Deploy to prod (needs openaddresses/openaddresses#8260 merged first for `size: large` to actually be live on `master`)
- [ ] Confirm the next NAD (`us/countrywide`) job run gets scheduled onto the `large` queue instead of `t3`