### PR TITLE
Isolate cleanup phases so one failing doesn't abort the rest

### DIFF
--- a/task/cleanup.js
+++ b/task/cleanup.js
@@ -14,7 +14,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     if (args.interactive) {
         await interactive();
     }
-    cli();
+    cli().catch((err) => {
+        console.error(err);
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(1);
+    });
 }
 
 async function cli() {
@@ -46,26 +50,38 @@ async function cli() {
 
     const stats = { kept: 0, pruned: 0, errors: 0, deduped: 0, orphaned: 0, failed: 0 };
 
-    try {
-        await pruneByRetention(oa, s3, r2, dryRun, stats);
-        await pruneOrphanedJobs(oa, s3, r2, dryRun, stats);
-        await pruneFailedJobs(oa, s3, r2, dryRun, stats);
-        await pruneNonLiveRuns(oa, s3, r2, dryRun, stats);
-        await sweepEmptyRuns(oa, dryRun, stats);
+    // Each phase runs independently - this job makes thousands of sequential
+    // API calls (@openaddresses/lib fetches a schema per query-param call, on
+    // top of the real request), and at that volume a single transient failure
+    // (network blip, an occasional API 500) is expected, not exceptional.
+    // Phases are individually idempotent, so letting one fail shouldn't cost
+    // the others their weekly chance to run.
+    const phases = [
+        ['pruneByRetention', () => pruneByRetention(oa, s3, r2, dryRun, stats)],
+        ['pruneOrphanedJobs', () => pruneOrphanedJobs(oa, s3, r2, dryRun, stats)],
+        ['pruneFailedJobs', () => pruneFailedJobs(oa, s3, r2, dryRun, stats)],
+        ['pruneNonLiveRuns', () => pruneNonLiveRuns(oa, s3, r2, dryRun, stats)],
+        ['sweepEmptyRuns', () => sweepEmptyRuns(oa, dryRun, stats)]
+    ];
 
-        console.error([
-            'ok - cleanup complete:',
-            `kept=${stats.kept}`,
-            `pruned=${stats.pruned}`,
-            `deduped=${stats.deduped}`,
-            `orphaned=${stats.orphaned}`,
-            `failed=${stats.failed}`,
-            `errors=${stats.errors}`
-        ].join(' '));
-    } catch (err) {
-        console.error(err);
-        throw err;
+    for (const [name, phase] of phases) {
+        try {
+            await phase();
+        } catch (err) {
+            console.error(`not ok - ${name} failed, continuing to next phase:`, err);
+            stats.errors++;
+        }
     }
+
+    console.error([
+        'ok - cleanup complete:',
+        `kept=${stats.kept}`,
+        `pruned=${stats.pruned}`,
+        `deduped=${stats.deduped}`,
+        `orphaned=${stats.orphaned}`,
+        `failed=${stats.failed}`,
+        `errors=${stats.errors}`
+    ].join(' '));
 }
 
 // ---- Retention-based pruning of live successful jobs ----


### PR DESCRIPTION
## Summary
- `task/cleanup.js`: the five cleanup phases (retention pruning, orphaned jobs, failed jobs, non-live runs, empty run sweep) now run in a loop with per-phase try/catch instead of one unbroken `await` chain. A failing phase logs, increments `stats.errors`, and the run continues to the next phase.
- Adds a top-level `.catch()` on the `cli()` invocation so any remaining unexpected error exits cleanly (`process.exit(1)`, so AWS Batch still marks the job Failed) instead of an unhandled promise rejection crash.

## Why
Requested before merging #612 (scheduling this to run weekly). Ran `--dry-run` against prod three times:
1. Completed the full retention-pruning phase, found 5,600+ orphaned-job candidates, then hit an uncaught `Error: Failed to fetch schema` partway through `pruneOrphanedJobs` and aborted entirely (~40 min in).
2. Hit my own test-harness timeout before finishing (not a real bug, just needed longer).
3. Got much further - completed retention pruning, orphaned jobs, and found real work in failed-job pruning - then hit a different uncaught error, `Error: 500: failed to fetch runs`, partway through `pruneNonLiveRuns`, and again aborted entirely.

Two full runs, two different crash points, both unrelated failures. At the request volume this job makes (thousands of sources' history lookups, plus `@openaddresses/lib` doing a schema-lookup HTTP call before every query-param request, doubling the real call count), an occasional transient failure is expected, not exceptional. Because the script was one unbroken chain, a single failure anywhere aborted every phase after it - in practice `pruneNonLiveRuns` and `sweepEmptyRuns` would likely rarely complete on the weekly cron even though their logic is fine.

## Test plan
- [x] `npm test` in `task/` - 65/65 passing, including all 21 `cleanup.test.js` cases (unaffected, they test `selectJobsToPrune` directly, not `cli()`)
- [ ] Re-run `cleanup.js --dry-run` against prod once more to confirm it now completes all 5 phases even if one hits a transient error