### PR TITLE
Fix Run.list crash and silently-dropped live filter

### DIFF
--- a/api/lib/types/run.js
+++ b/api/lib/types/run.js
@@ -83,9 +83,10 @@ export default class Run extends Generic {
         Status.verify(query.status);
 
         if (!query.run) query.run = null;
-        if (!query.live || query.live === 'all') query.live = null;
-        else if (query.live === 'true') query.live = true;
-        else if (query.live === 'false') query.live = false;
+        if (query.live === undefined || query.live === null || query.live === 'all') query.live = null;
+        else if (query.live === true || query.live === 'true') query.live = true;
+        else if (query.live === false || query.live === 'false') query.live = false;
+        else query.live = null;
 
         if (query.after) {
             try {
@@ -103,6 +104,11 @@ export default class Run extends Generic {
             }
         }
 
+        // slonik's sql tag only accepts primitives or SQL tokens - a raw Moment
+        // instance interpolated directly throws "Expected token to include
+        // 'type' property", so convert to an ISO string (or null) up front.
+        const after = query.after ? query.after.toDate().toISOString() : null;
+        const before = query.before ? query.before.toDate().toISOString() : null;
 
         let pgres;
         try {
@@ -123,8 +129,8 @@ export default class Run extends Generic {
                 WHERE
                     ${sql.array(query.status, sql`TEXT[]`)} @> ARRAY[job.status]
                     AND (${query.run}::BIGINT IS NULL OR run = ${query.run})
-                    AND (${query.after}::TIMESTAMP IS NULL OR runs.created > ${query.after ? query.after.toDate().toISOString() : null}::TIMESTAMP)
-                    AND (${query.before}::TIMESTAMP IS NULL OR runs.created < ${query.before ? query.before.toDate().toISOString() : null}::TIMESTAMP)
+                    AND (${after}::TIMESTAMP IS NULL OR runs.created > ${after}::TIMESTAMP)
+                    AND (${before}::TIMESTAMP IS NULL OR runs.created < ${before}::TIMESTAMP)
                     AND (${query.live}::BOOLEAN IS NULL OR runs.live = ${query.live})
                 GROUP BY
                     runs.id,


### PR DESCRIPTION
## Summary

`GET /run` with `before`/`after` params was throwing a 500 in production (`failed to fetch runs`), which is what `task/cleanup.js`'s `pruneNonLiveRuns()` phase hits every run since it always passes `before`.

Confirmed via CloudWatch logs on the live ECS service (`batch-prod` log group) and by reproducing directly against `https://batch.openaddresses.io/api/run`:

```
UnexpectedStateError: Expected token to include "type" property.
    at isSqlToken (slonik/dist/src/utilities/isSqlToken.js:26:15)
    at createQuery (slonik/dist/src/factories/createSqlTag.js:39:45)
    at sql (slonik/dist/src/factories/createSqlTag.js:61:43)
    at Run.list (api/lib/types/run.js:109:41)
```

Root cause: in `Run.list`, `query.before`/`query.after` are reassigned to `moment(...)` instances, and the first half of each `IS NULL` guard interpolated that raw Moment object directly into the slonik `sql` tagged template:

```js
AND (${query.after}::TIMESTAMP IS NULL OR runs.created > ${query.after ? query.after.toDate().toISOString() : null}::TIMESTAMP)
```

slonik's `sql` tag only accepts primitives or its own SQL tokens — a Moment instance is neither, so the tag throws while *building* the query, before it ever reaches Postgres. This reproduces on `before`/`after` alone, regardless of value, and is unrelated to `live`.

Fix: compute the ISO string (or `null`) once, and reuse that primitive on both sides of each guard instead of the raw Moment object.

While investigating I also found the `live` filter (recently added to support the cleanup job's `live=false` runs) was silently being ignored whenever `false` was passed:

```js
if (!query.live || query.live === 'all') query.live = null;
```

`live: false` is a meaningful, valid filter value, but it's falsy, so this branch nulled it out — the query then returned both live and non-live runs. Confirmed against prod: `GET /run?live=false` and `GET /run` (no filter) returned the same `total` count. Fixed with explicit `undefined`/`null` checks instead of a truthiness check, handling both the raw querystring value and the boolean ajv coerces it to.

## Test plan

- [x] Reproduced the 500 directly against `https://batch.openaddresses.io/api/run?before=...` and `?after=...`, and confirmed via CloudWatch logs on `batch-prod` that the underlying error is the slonik `UnexpectedStateError` above.
- [x] Verified the fix by calling `Run.list()` locally (Node 22) against a stubbed `pool.query`, covering: `before` alone, `after` alone, `live=false` + `before` (the exact combination `pruneNonLiveRuns` sends), `live=false` alone, `live=true` alone, and no params. All construct the query without throwing.
- [x] Verified the `live` filter now produces the correct `false`/`true`/`null` bind value for string `'false'`/`'true'`, boolean `false`/`true` (as ajv's `coerceTypes` would produce), and unset.
- [x] `npx eslint lib/types/run.js` passes.
- [ ] Could not run the full API test suite locally — `npm test` in `api/` needs a live Postgres instance and fails on all tests with an unrelated pre-existing environment issue (`Cannot read properties of undefined (reading 'close')` in `flight.js`), independent of this change.