### PR TITLE
Fix sustained RDS CPU load from cleanup task's queries

### DIFF
--- a/api/lib/types/job.js
+++ b/api/lib/types/job.js
@@ -31,6 +31,13 @@ export default class Job extends Generic {
      * @param {String} [query.after=undefined] - Only show jobs after the given date
      * @param {String} [query.source=Null] - Filter results by source
      * @param {String[]} [query.status=["Success", "Fail", "Pending", "Warn"]] - Only show jobs with given status
+     * @param {Boolean} [query.count=true] - Compute the exact total match count (count(*) OVER()).
+     *   Callers that only sweep pages sequentially (eg cleanup.js) don't use `total` and can set this to
+     *   false to skip the extra work of computing an exact count on every page.
+     * @param {Number} [query.cursor=undefined] - If set, keyset-paginate: only return jobs with
+     *   `id > cursor`, ordered by id ascending (overriding `sort`/`order`/`page`). Cheaper than
+     *   `page`/OFFSET for callers sweeping the full result set page by page, and - unlike OFFSET -
+     *   isn't thrown off by rows being deleted between page fetches.
      */
     static async list(pool, query = {}) {
         query.limit = Params.integer(query.limit, { default: 100 });
@@ -39,6 +46,8 @@ export default class Job extends Generic {
         query.run = Params.integer(query.run);
         query.sort = Params.string(query.sort, { default: 'id' });
         query.order = Params.order(query.order);
+        query.count = Params.boolean(query.count, { default: true });
+        query.cursor = Params.integer(query.cursor);
 
         if (!query.layer || query.layer === 'all') query.layer = '';
         if (!query.live || query.live === 'all') query.live = null;
@@ -46,6 +55,13 @@ export default class Job extends Generic {
 
         if (!query.after) query.after = null;
         if (!query.before) query.before = null;
+
+        // Keyset pagination overrides page-number/OFFSET pagination: always walks
+        // id ascending so a cursor of "last id seen" is well defined.
+        if (query.cursor !== null) {
+            query.sort = 'id';
+            query.order = sql`asc`;
+        }
 
         Status.verify(query.status);
 
@@ -73,7 +89,7 @@ export default class Job extends Generic {
         try {
             pgres = await pool.query(sql`
                 SELECT
-                    count(*) OVER() AS count,
+                    ${query.count ? sql`count(*) OVER() AS count,` : sql``}
                     job.id,
                     job.run,
                     job.map,
@@ -90,7 +106,7 @@ export default class Job extends Generic {
                     job INNER JOIN runs
                         ON job.run = runs.id
                 WHERE
-                    ${sql.array(query.status, sql`TEXT[]`)} @> ARRAY[job.status]
+                    job.status = ANY(${sql.array(query.status, sql`TEXT[]`)})
                     AND job.layer ilike ${query.layer}
                     AND job.source ilike ${query.source}
                     AND (${query.run}::BIGINT IS NULL OR job.run = ${query.run})
@@ -98,12 +114,13 @@ export default class Job extends Generic {
                     AND (${query.before ? query.before.toDate().toISOString() : null}::TIMESTAMP IS NULL OR job.created < ${query.before ? query.before.toDate().toISOString() : null}::TIMESTAMP)
                     AND (${query.run}::BIGINT IS NULL OR job.run = ${query.run})
                     AND (${query.live}::BOOLEAN IS NULL OR runs.live = ${query.live})
+                    AND (${query.cursor}::BIGINT IS NULL OR job.id > ${query.cursor})
                 ORDER BY
                     ${sql.identifier([this._table, query.sort])} ${query.order}
                 LIMIT
                     ${query.limit}
                 OFFSET
-                    ${query.limit * query.page}
+                    ${query.cursor !== null ? 0 : query.limit * query.page}
             `);
         } catch (err) {
             throw new Err(500, err, 'Failed to load jobs');
@@ -138,10 +155,18 @@ export default class Job extends Generic {
      * @param {String} query.before - Only return orphaned jobs created before this date
      * @param {Number} [query.limit=100] - Max results per page
      * @param {Number} [query.page=0] - Page number
+     * @param {Boolean} [query.count=true] - Compute the exact total match count (count(*) OVER()).
+     *   Set to false to skip this when sweeping pages sequentially and `total` isn't used.
+     * @param {Number} [query.cursor=undefined] - If set, keyset-paginate: only return jobs with
+     *   `id > cursor` (overriding `page`/OFFSET). Cheaper for callers sweeping the full result set,
+     *   and immune to OFFSET drift when rows are deleted between page fetches (as this endpoint's
+     *   only caller, cleanup.js, does).
      */
     static async orphaned(pool, query = {}) {
         query.limit = Params.integer(query.limit, { default: 100 });
         query.page = Params.integer(query.page, { default: 0 });
+        query.count = Params.boolean(query.count, { default: true });
+        query.cursor = Params.integer(query.cursor);
 
         if (!query.before) throw new Err(400, null, 'before parameter required');
 
@@ -155,7 +180,7 @@ export default class Job extends Generic {
         try {
             const pgres = await pool.query(sql`
                 SELECT
-                    count(*) OVER() AS count,
+                    ${query.count ? sql`count(*) OVER() AS count,` : sql``}
                     job.id,
                     job.run,
                     job.created,
@@ -170,6 +195,7 @@ export default class Job extends Generic {
                     job
                 WHERE
                     job.created < ${before.toDate().toISOString()}::TIMESTAMP
+                    AND (${query.cursor}::BIGINT IS NULL OR job.id > ${query.cursor})
                     AND NOT EXISTS (
                         SELECT 1 FROM results
                         WHERE results.source = job.source_name
@@ -177,11 +203,11 @@ export default class Job extends Generic {
                         AND results.name = job.name
                     )
                 ORDER BY
-                    job.created DESC
+                    job.id ASC
                 LIMIT
                     ${query.limit}
                 OFFSET
-                    ${query.limit * query.page}
+                    ${query.cursor !== null ? 0 : query.limit * query.page}
             `);
 
             return this.deserialize_list(pgres, 'jobs');

--- a/api/lib/types/run.js
+++ b/api/lib/types/run.js
@@ -67,6 +67,13 @@ export default class Run extends Generic {
      * @param {String} [query.before=undefined] - Only show runs before the given date
      * @param {String} [query.after=undefined] - Only show jobs after the given date
      * @param {Number} [query.status=["Success", "Fail", "Running", "Pending", "Warn"]] - Only show runs with a given status
+     * @param {Boolean} [query.count=true] - Compute the exact total match count (count(*) OVER()).
+     *   Callers that only sweep pages sequentially (eg cleanup.js) don't use `total` and can set this
+     *   to false to skip the extra work of computing an exact count on every page.
+     * @param {Number} [query.cursor=undefined] - If set, keyset-paginate: only return runs with
+     *   `id > cursor`, ordered by id ascending (overriding `sort`/`order`/`page`). Cheaper than
+     *   `page`/OFFSET for callers sweeping the full result set, and immune to OFFSET drift when
+     *   rows are deleted between page fetches (as cleanup.js does).
      */
     static async list(pool, query) {
         if (!query) query = {};
@@ -76,9 +83,18 @@ export default class Run extends Generic {
         query.limit = Params.integer(query.limit, { default: 100 });
         query.sort = Params.string(query.sort, { default: 'id' });
         query.order = Params.order(query.order);
+        query.count = Params.boolean(query.count, { default: true });
+        query.cursor = Params.integer(query.cursor);
 
         if (!query.after) query.after = null;
         if (!query.before) query.before = null;
+
+        // Keyset pagination overrides page-number/OFFSET pagination: always walks
+        // id ascending so a cursor of "last id seen" is well defined.
+        if (query.cursor !== null) {
+            query.sort = 'id';
+            query.order = sql`asc`;
+        }
 
         Status.verify(query.status);
 
@@ -114,7 +130,7 @@ export default class Run extends Generic {
         try {
             pgres = await pool.query(sql`
                 SELECT
-                    count(*) OVER() AS count,
+                    ${query.count ? sql`count(*) OVER() AS count,` : sql``}
                     runs.id,
                     runs.live,
                     runs.created,
@@ -127,11 +143,12 @@ export default class Run extends Generic {
                         LEFT JOIN job
                         ON job.run = runs.id
                 WHERE
-                    ${sql.array(query.status, sql`TEXT[]`)} @> ARRAY[job.status]
+                    job.status = ANY(${sql.array(query.status, sql`TEXT[]`)})
                     AND (${query.run}::BIGINT IS NULL OR run = ${query.run})
                     AND (${after}::TIMESTAMP IS NULL OR runs.created > ${after}::TIMESTAMP)
                     AND (${before}::TIMESTAMP IS NULL OR runs.created < ${before}::TIMESTAMP)
                     AND (${query.live}::BOOLEAN IS NULL OR runs.live = ${query.live})
+                    AND (${query.cursor}::BIGINT IS NULL OR runs.id > ${query.cursor})
                 GROUP BY
                     runs.id,
                     runs.live,
@@ -143,7 +160,7 @@ export default class Run extends Generic {
                 LIMIT
                     ${query.limit}
                 OFFSET
-                    ${query.limit * query.page}
+                    ${query.cursor !== null ? 0 : query.limit * query.page}
             `);
 
             const list = this.deserialize_list(pgres, 'runs');

--- a/api/migrations/20260801000000_cleanup-perf-indexes.js
+++ b/api/migrations/20260801000000_cleanup-perf-indexes.js
@@ -1,0 +1,45 @@
+// Indexes supporting the weekly cleanup task's queries (task/cleanup.js):
+//  - job(status, id): Job.list() filters on job.status and (by default) orders/
+//    keyset-paginates on job.id - used heavily by pruneFailedJobs.
+//  - job(created): Job.list()'s before/after filters and Job.orphaned()'s
+//    before filter, both currently unindexed.
+//  - job(source_name, layer, name): Data.history()'s join from results to job -
+//    pruneByRetention calls this once per active source (~5k sequential calls),
+//    each of which was doing a full seq scan of job to find the match.
+//  - job(run): Run.list()'s LEFT JOIN job ON job.run = runs.id, used by
+//    pruneNonLiveRuns/sweepEmptyRuns.
+//  - results(source, layer, name): Job.orphaned()'s NOT EXISTS anti-join
+//    against results, evaluated per candidate job row.
+//  - runs(live): Run.list()'s live filter, used by pruneNonLiveRuns.
+//
+// CREATE INDEX CONCURRENTLY is used so this doesn't take a blocking lock
+// against the live job/runs/results tables. That requires each statement to
+// run outside of a transaction - both via knex's per-migration `transaction:
+// false` config below, *and* by issuing each CREATE/DROP INDEX as its own
+// knex.schema.raw() call: a single raw() call containing multiple
+// semicolon-separated statements is sent to Postgres as one "simple query"
+// message, which Postgres itself implicitly wraps in a transaction
+// regardless of the knex-level transaction setting - and CONCURRENTLY is not
+// allowed inside any transaction block.
+export const config = { transaction: false };
+
+const indexes = [
+    ['job_status_id_idx', 'job(status, id)'],
+    ['job_created_idx', 'job(created)'],
+    ['job_source_name_layer_name_idx', 'job(source_name, layer, name)'],
+    ['job_run_idx', 'job(run)'],
+    ['results_source_layer_name_idx', 'results(source, layer, name)'],
+    ['runs_live_idx', 'runs(live)']
+];
+
+export async function up(knex) {
+    for (const [name, on] of indexes) {
+        await knex.schema.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS ${name} ON ${on}`);
+    }
+}
+
+export async function down(knex) {
+    for (const [name] of indexes) {
+        await knex.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${name}`);
+    }
+}

--- a/api/schema/req.query.ListJobs.json
+++ b/api/schema/req.query.ListJobs.json
@@ -25,6 +25,15 @@
         "page": {
             "$ref": "./util/page.json"
         },
+        "count": {
+            "type": "boolean",
+            "default": true,
+            "description": "Compute the exact total match count (count(*) OVER()). Set to false to skip this on callers that don't use the `total` response field and only sweep pages sequentially - it's otherwise recomputed on every page."
+        },
+        "cursor": {
+            "type": "integer",
+            "description": "Keyset-paginate: only return jobs with id greater than this value, ordered by id ascending (overrides sort/order/page). Cheaper than page/limit for sweeping the full result set."
+        },
         "sort": {
             "type": "string",
             "default": "id",

--- a/api/schema/req.query.ListOrphanedJobs.json
+++ b/api/schema/req.query.ListOrphanedJobs.json
@@ -15,6 +15,15 @@
         },
         "page": {
             "$ref": "./util/page.json"
+        },
+        "count": {
+            "type": "boolean",
+            "default": true,
+            "description": "Compute the exact total match count (count(*) OVER()). Set to false to skip this on callers that don't use the `total` response field and only sweep pages sequentially - it's otherwise recomputed on every page."
+        },
+        "cursor": {
+            "type": "integer",
+            "description": "Keyset-paginate: only return jobs with id greater than this value (overrides page). Cheaper than page/limit for sweeping the full result set."
         }
     }
 }

--- a/api/schema/req.query.ListRuns.json
+++ b/api/schema/req.query.ListRuns.json
@@ -11,6 +11,15 @@
         "page": {
             "$ref": "./util/page.json"
         },
+        "count": {
+            "type": "boolean",
+            "default": true,
+            "description": "Compute the exact total match count (count(*) OVER()). Set to false to skip this on callers that don't use the `total` response field and only sweep pages sequentially - it's otherwise recomputed on every page."
+        },
+        "cursor": {
+            "type": "integer",
+            "description": "Keyset-paginate: only return runs with id greater than this value, ordered by id ascending (overrides sort/order/page). Cheaper than page/limit for sweeping the full result set."
+        },
         "order": {
             "$ref": "./util/order.json"
         },

--- a/task/cleanup.js
+++ b/task/cleanup.js
@@ -163,9 +163,11 @@ async function pruneOrphanedJobs(oa, s3, r2, dryRun, stats) {
     threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
     const before = threeMonthsAgo.toISOString().split('T')[0];
 
-    let page = 0;
+    let cursor;
     while (true) {
-        const result = await oa.cmd('job', 'orphaned', { before, limit: 100, page });
+        const params = { before, limit: 100, count: false };
+        if (cursor !== undefined) params.cursor = cursor;
+        const result = await oa.cmd('job', 'orphaned', params);
         const jobs = result.jobs || [];
         if (jobs.length === 0) break;
 
@@ -173,8 +175,8 @@ async function pruneOrphanedJobs(oa, s3, r2, dryRun, stats) {
         stats.orphaned += toDelete.length;
         await deleteJobsBatch(oa, s3, r2, toDelete, dryRun, stats);
 
+        cursor = jobs[jobs.length - 1].id;
         if (jobs.length < 100) break;
-        page++;
     }
 }
 
@@ -187,9 +189,11 @@ async function pruneFailedJobs(oa, s3, r2, dryRun, stats) {
     threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
     const before = threeMonthsAgo.toISOString().split('T')[0];
 
-    let page = 0;
+    let cursor;
     while (true) {
-        const result = await oa.cmd('job', 'list', { status: 'Fail', before, live: true, limit: 100, page });
+        const params = { status: 'Fail', before, live: true, limit: 100, count: false };
+        if (cursor !== undefined) params.cursor = cursor;
+        const result = await oa.cmd('job', 'list', params);
         const jobs = result.jobs || [];
         if (jobs.length === 0) break;
 
@@ -197,8 +201,8 @@ async function pruneFailedJobs(oa, s3, r2, dryRun, stats) {
         stats.failed += toDelete.length;
         await deleteJobsBatch(oa, s3, r2, toDelete, dryRun, stats);
 
+        cursor = jobs[jobs.length - 1].id;
         if (jobs.length < 100) break;
-        page++;
     }
 }
 
@@ -211,9 +215,11 @@ async function pruneNonLiveRuns(oa, s3, r2, dryRun, stats) {
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
     const before = sevenDaysAgo.toISOString().split('T')[0];
 
-    let page = 0;
+    let cursor;
     while (true) {
-        const result = await oa.cmd('run', 'list', { live: false, before, limit: 100, page });
+        const params = { live: false, before, limit: 100, count: false };
+        if (cursor !== undefined) params.cursor = cursor;
+        const result = await oa.cmd('run', 'list', params);
         const runs = result.runs || [];
         if (runs.length === 0) break;
 
@@ -233,8 +239,8 @@ async function pruneNonLiveRuns(oa, s3, r2, dryRun, stats) {
             }
         }
 
+        cursor = runs[runs.length - 1].id;
         if (runs.length < 100) break;
-        page++;
     }
 }
 
@@ -243,10 +249,12 @@ async function pruneNonLiveRuns(oa, s3, r2, dryRun, stats) {
 async function sweepEmptyRuns(oa, dryRun, stats) {
     console.error('ok - sweeping empty runs');
 
-    let page = 0;
+    let cursor;
     let swept = 0;
     while (true) {
-        const result = await oa.cmd('run', 'list', { limit: 100, page });
+        const params = { limit: 100, count: false };
+        if (cursor !== undefined) params.cursor = cursor;
+        const result = await oa.cmd('run', 'list', params);
         const runs = result.runs || [];
         if (runs.length === 0) break;
 
@@ -267,8 +275,8 @@ async function sweepEmptyRuns(oa, dryRun, stats) {
             }
         }
 
+        cursor = runs[runs.length - 1].id;
         if (runs.length < 100) break;
-        page++;
     }
 
     console.error(`ok - swept ${swept} empty runs`);


### PR DESCRIPTION
## Summary

`task/cleanup.js` was pinning RDS CPU at 70-95% for the full duration of every run (40-100 min, confirmed via CloudWatch). Investigation found two compounding causes, plus a bonus correctness issue with the existing pagination:

1. **Missing index on `job(source_name, layer, name)`.** `pruneByRetention` calls `data.history` once per active source (~5,089 sequential calls). That query joins `results` to `job` on `source_name`/`layer`/`name` with no supporting index, so every single one of those 5,089 calls did a full sequential scan of the `job` table. Given the `job` table is large (>104k `Fail` rows alone, likely far more total), this is almost certainly the single biggest contributor to sustained CPU - it's unconditional, happens on every run, and isn't improved by any pagination change.
2. **OFFSET pagination with no supporting indexes**, compounding at `pruneFailedJobs`'s ~1,044 pages of `job.list` (104k+ matching rows) and `pruneOrphanedJobs`'s ~63 pages of `job.orphaned` (which also runs a correlated `NOT EXISTS` against `results` on every candidate row, and `results` had no supporting index either). OFFSET pagination requires scanning and discarding every prior row on each page, so cost grows with page depth - this is the quadratic-cost pattern originally suspected.
3. Confirmed the exact `count(*) OVER()` computed on every `job.list`/`job.orphaned`/`run.list` page is indeed unused by any of cleanup.js's callers (they only check `results.length < limit`) - it's pure wasted work for this caller, while still needed for the admin web UI's paged tables (`api/web/src/components/Jobs.vue`, `Runs.vue`), which use both the exact `total` and arbitrary-page OFFSET jumps via `TableFooter`/`TablerPager`. So it's now optional rather than removed.
4. **Bonus finding, not fixed here (out of scope):** `Run.list`'s OFFSET pagination combined with the same-run deletions cleanup.js performs (`pruneNonLiveRuns`, `sweepEmptyRuns`) is a correctness hazard, not just a perf one - deleting rows mid-sweep shifts subsequent OFFSETs, silently skipping rows. Verified this concretely (see test plan). Cursor pagination is immune to this, which is a second reason (beyond perf) to prefer it for sequential full-table sweeps like cleanup.js's.

## Changes

- **New migration** (`api/migrations/20260801000000_cleanup-perf-indexes.js`): adds `job(status, id)`, `job(created)`, `job(source_name, layer, name)`, `job(run)`, `results(source, layer, name)`, `runs(live)`. Uses `CREATE INDEX CONCURRENTLY` (each as its own statement/query, since Postgres implicitly wraps multi-statement "simple query" batches in a transaction regardless of knex's per-migration `transaction: false`, and `CONCURRENTLY` can't run inside one) so this doesn't take a blocking lock against the live tables.
- **`Job.list`, `Job.orphaned`, `Run.list`**: added an optional `count` flag (default `true`, preserving current behavior) that skips the `count(*) OVER()` computation, and an optional `cursor` param for keyset pagination (`id > cursor`, ordered by id ascending) as an alternative to `page`/OFFSET. `Job.orphaned`'s previously-hardcoded `ORDER BY created DESC` is now `ORDER BY id ASC` to support this - it's an admin-only endpoint with cleanup.js as its only known caller (no web UI usage), so this is low risk. Also rewrote the `status` filter from `ARRAY[...] @> ARRAY[job.status]` to `job.status = ANY(...)` in both `Job.list` and `Run.list` - semantically identical (verified against NULL-status LEFT JOIN rows too), but indexable by a plain btree, unlike the containment form.
- **`task/cleanup.js`**: updated only the four pagination loops (`pruneOrphanedJobs`, `pruneFailedJobs`, `pruneNonLiveRuns`, `sweepEmptyRuns`) to track a `cursor` instead of a `page` counter and pass `count: false`. No changes to retry/error handling, `selectJobsToPrune`, or `deleteJobsBatch`.

## Why I'm confident this reduces load

- The `job(source_name, layer, name)` index directly targets the highest-multiplicity cost (5,089 calls/run) with a query-shape that matches the index prefix exactly (equality on all three columns) - this should turn each of those from a full table scan into an index lookup.
- Keyset pagination changes the total scanned-row cost for a full sweep from O(n²/limit) (OFFSET) to O(n) - each page only scans forward from the last cursor, never re-scanning/discarding everything before it. Combined with the new indexes (`job(status, id)` covers `pruneFailedJobs`'s filter+order in one index), pages should become cheap, narrow index range scans.
- Verified locally against a real Postgres (docker-compose's `postgis` service) rather than just reasoning about query shape:
  - Confirmed all 6 indexes are created successfully via `CREATE INDEX CONCURRENTLY`.
  - Exercised `Job.list`/`Job.orphaned` cursor sweeps end-to-end: pages return monotonically increasing, non-overlapping, deduplicated ids covering the full seeded dataset.
  - Confirmed `count: false` correctly skips the exact count (falls back to page-length, which cleanup.js never reads) while the default (`count` omitted) still returns the correct exact `total`, matching current behavior for the web UI.
  - Directly reproduced the delete-during-sweep correctness hazard: with OFFSET pagination, deleting a page's rows before fetching the next page skips rows; with cursor pagination, the same delete-then-continue sequence returns every row exactly once.
- I could not run `cleanup.js` against production to confirm the CPU improvement directly (explicitly out of scope), and API tests need a live Postgres my sandbox doesn't have wired to prod - all verification above was against a local Postgres via `docker-compose up postgis`.

## What I did *not* change

- `task/cleanup.js`'s retry/error handling, `selectJobsToPrune`, and `deleteJobsBatch` - out of scope, already hardened/merged separately.
- `Run.list`'s fix from #617 - untouched.
- The pre-existing `ARRAY_LENGTH(ARRAY_AGG(job.status), 0)` bug in `Run.list` (dimension argument should be `1`, not `0` - this makes `jobs` always come back `null` in the response) - noticed it while investigating why `sweepEmptyRuns`'s `run.jobs === null` branch behaves oddly, but it's a pre-existing correctness bug unrelated to RDS load, so left it alone rather than scope-creep. Worth a follow-up issue.

## Test plan

- [x] `task/` unit tests pass (`nvm use 22 && npm test` in `task/`) - 65/65, unchanged by this PR (`selectJobsToPrune` untouched)
- [x] `eslint` clean on both `api/` and `task/` changed files
- [x] Ran real migrations + exercised the new query paths against a local Postgres (`docker-compose up postgis`), including the delete-during-sweep correctness check described above
- [x] `api/` test suite needs a live Postgres wired up beyond what's available in my sandbox for a full CI-equivalent run; recommend CI runs it as usual before merge