### PR TITLE
Fix API crash from unset Schemas limit option after body-parser bump

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -109,7 +109,8 @@ export default async function server(config) {
 
     const schema = new Schema(express.Router(), {
         schemas: new URL('./schema', import.meta.url),
-        openapi: true
+        openapi: true,
+        limit: 50
     });
 
     app.disable('x-powered-by');


### PR DESCRIPTION
## Summary
`api/index.js` instantiates `@openaddresses/batch-schema`'s `Schema` without a `limit` option. That package's constructor documents `opts.limit` as defaulting to 50 but never actually implements the default - it directly does `bodyparser.json({ limit: \`${opts.limit}mb\` })`, so an unset `limit` produces the literal string `"undefinedmb"`.

`body-parser` 1.20.5 apparently tolerated that silently. 1.20.6 (bumped in #610) validates the `limit` option strictly and throws instead:
```
TypeError: option limit "undefinedmb" is invalid
    at Function.json (body-parser/lib/types/json.js:66)
    at new Schemas (@openaddresses/batch-schema/lib/schema.js:47)
    at server (api/index.js:110)
```
This crashed every API task on startup after tonight's deploy (`batch-prod:438`), pinning the ECS service in a crash-loop while the previous task definition kept serving traffic.

## Fix
Pass `limit: 50` explicitly at the call site - matches the documented intended default, entirely within this repo, no need to touch the external package.

## Urgency
This is blocking the currently-stuck `batch-prod` deploy - merging and redeploying should let the new task definition actually start.