### PR TITLE
Show layers with no successful run on the batch data page

### DIFF
--- a/api/lib/types/data.js
+++ b/api/lib/types/data.js
@@ -65,6 +65,14 @@ export default class Data extends Generic {
             namePattern = `${query.name}%`;
         }
 
+        // Only the batch dashboard's listing view opts into "failing" rows (via
+        // ?failing=true) - task/collect.js and task/fabric.js call this with no
+        // query params to build the downloadable collections/fabric tiles, and
+        // must keep seeing exactly the sources with real output they had before.
+        // Data.update()/Job.delta() use exact:true as a "does a real results row
+        // exist" lookup and must never see a synthetic failing row as a match.
+        const includeFailing = !!query.failing && !query.exact;
+
         try {
             // "failing" covers source/layer/name combos with no row in `results` -
             // i.e. the layer has never had a successful live-run job - so a
@@ -87,6 +95,7 @@ export default class Data extends Generic {
                     WHERE
                         runs.live = true
                         AND job.status = 'Fail'
+                        AND ${includeFailing} = true
                         AND NOT EXISTS (
                             SELECT 1 FROM results
                             WHERE

--- a/api/lib/types/data.js
+++ b/api/lib/types/data.js
@@ -66,7 +66,40 @@ export default class Data extends Generic {
         }
 
         try {
+            // "failing" covers source/layer/name combos with no row in `results` -
+            // i.e. the layer has never had a successful live-run job - so a
+            // contributor has a way to discover and debug it. Restricted to
+            // job.status = 'Fail' so a first job that's merely Pending/Running
+            // doesn't get flagged as broken before it's had a chance to run.
             const pgres = await pool.query(sql`
+                WITH failing AS (
+                    SELECT DISTINCT ON (job.source_name, job.layer, job.name)
+                        job.id,
+                        job.source_name AS source,
+                        job.layer,
+                        job.name,
+                        job.output,
+                        job.size,
+                        job.map
+                    FROM
+                        job
+                            INNER JOIN runs ON job.run = runs.id
+                    WHERE
+                        runs.live = true
+                        AND job.status = 'Fail'
+                        AND NOT EXISTS (
+                            SELECT 1 FROM results
+                            WHERE
+                                results.source = job.source_name
+                                AND results.layer = job.layer
+                                AND results.name = job.name
+                        )
+                    ORDER BY
+                        job.source_name,
+                        job.layer,
+                        job.name,
+                        job.created DESC
+                )
                 SELECT
                     results.id,
                     results.fabric,
@@ -97,10 +130,41 @@ export default class Data extends Generic {
                     )
                     AND (${query.fabric}::BOOLEAN IS NULL OR results.fabric = ${!!query.fabric})
                     AND (${query.validated}::BOOLEAN IS NULL OR (job.output->'validated')::BOOLEAN = ${!!query.validated})
+
+                UNION ALL
+
+                SELECT
+                    (-1 * failing.id) AS id,
+                    false AS fabric,
+                    failing.source,
+                    NULL::TIMESTAMP AS updated,
+                    failing.layer,
+                    failing.name,
+                    failing.id AS job,
+                    failing.output,
+                    failing.size,
+                    failing.map
+                FROM
+                    failing
+                        LEFT JOIN map ON failing.map = map.id
+                WHERE
+                    failing.source ilike ${sourcePattern}
+                    AND failing.layer ilike ${layerPattern}
+                    AND failing.name ilike ${namePattern}
+                    AND ${query.before}::TIMESTAMP IS NULL
+                    AND ${query.after}::TIMESTAMP IS NULL
+                    AND (${query.map}::BIGINT IS NULL OR failing.map = ${query.map})
+                    AND (
+                        char_length(${query.point}) = 0
+                        OR ST_DWithin(ST_SetSRID(ST_PointFromText(${query.point}), 4326), map.geom, 1.0)
+                    )
+                    AND (${query.fabric}::BOOLEAN IS NULL OR ${!!query.fabric} = false)
+                    AND (${query.validated}::BOOLEAN IS NULL OR (failing.output->'validated')::BOOLEAN = ${!!query.validated})
+
                 ORDER BY
-                    results.source,
-                    results.layer,
-                    results.name
+                    source,
+                    layer,
+                    name
             `);
 
             pgres.rows.map((res) => {

--- a/api/schema/req.query.ListData.json
+++ b/api/schema/req.query.ListData.json
@@ -37,6 +37,10 @@
         "map": {
             "type": "integer",
             "description": "Filter by associated MapID"
+        },
+        "failing": {
+            "type": "boolean",
+            "description": "Also include source/layer/names with no successful live-run job, so they can be discovered and debugged"
         }
     }
 }

--- a/api/schema/util/updated.json
+++ b/api/schema/util/updated.json
@@ -1,4 +1,4 @@
 {
-    "type": "integer",
+    "type": ["null", "integer"],
     "description": "The timestamp at which the resource was last updated"
 }

--- a/api/web/src/components/Data.vue
+++ b/api/web/src/components/Data.vue
@@ -327,7 +327,14 @@
                                                             class='col-2 d-flex align-items-center'
                                                             @click='emitjob(job.job)'
                                                         >
-                                                            <span v-text='fmt(job.updated)' />
+                                                            <span
+                                                                v-if='job.updated'
+                                                                v-text='fmt(job.updated)'
+                                                            />
+                                                            <span
+                                                                v-else
+                                                                class='text-red'
+                                                            >No successful run</span>
                                                         </div>
                                                         <div class='col-5 d-flex'>
                                                             <div class='ms-auto btn-list'>
@@ -338,34 +345,36 @@
                                                                     @perk='$emit("perk", $event)'
                                                                 />
 
-                                                                <template v-if='auth && auth.access === "admin"'>
-                                                                    <TablerDropdown>
-                                                                        <slot>
-                                                                            <IconSettings
-                                                                                class='cursor-pointer'
-                                                                                size='32'
-                                                                                stroke='1'
-                                                                                title='Admin settings'
-                                                                            />
-                                                                        </slot>
-                                                                        <template #dropdown>
-                                                                            <TablerToggle
-                                                                                v-model='job.fabric'
-                                                                                label='Fabric'
-                                                                                @change='updateData(job)'
-                                                                            />
-                                                                            <TablerDelete @delete='deleteData(job)' />
-                                                                        </template>
-                                                                    </TablerDropdown>
-                                                                </template>
+                                                                <template v-if='job.id > 0'>
+                                                                    <template v-if='auth && auth.access === "admin"'>
+                                                                        <TablerDropdown>
+                                                                            <slot>
+                                                                                <IconSettings
+                                                                                    class='cursor-pointer'
+                                                                                    size='32'
+                                                                                    stroke='1'
+                                                                                    title='Admin settings'
+                                                                                />
+                                                                            </slot>
+                                                                            <template #dropdown>
+                                                                                <TablerToggle
+                                                                                    v-model='job.fabric'
+                                                                                    label='Fabric'
+                                                                                    @change='updateData(job)'
+                                                                                />
+                                                                                <TablerDelete @delete='deleteData(job)' />
+                                                                            </template>
+                                                                        </TablerDropdown>
+                                                                    </template>
 
-                                                                <IconHistory
-                                                                    class='cursor-pointer'
-                                                                    size='32'
-                                                                    stroke='1'
-                                                                    title='View history'
-                                                                    @click='$router.push(`/data/${job.id}/history`)'
-                                                                />
+                                                                    <IconHistory
+                                                                        class='cursor-pointer'
+                                                                        size='32'
+                                                                        stroke='1'
+                                                                        title='View history'
+                                                                        @click='$router.push(`/data/${job.id}/history`)'
+                                                                    />
+                                                                </template>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/api/web/src/components/Data.vue
+++ b/api/web/src/components/Data.vue
@@ -564,6 +564,7 @@ export default {
                 this.loading.sources = true;
 
                 const url = window.stdurl('/api/data');
+                url.searchParams.set('failing', 'true');
                 if (this.filter.source) url.searchParams.set('source', this.filter.source);
                 if (this.filter.layer !== 'all') url.searchParams.set('layer', this.filter.layer);
                 if (this.filter.point) url.searchParams.set('point', this.filter.point.join(','));

--- a/task/collect.js
+++ b/task/collect.js
@@ -119,6 +119,14 @@ async function collect(tmp, collection, oa) {
 }
 
 async function sources(oa, tmp, datas) {
+    datas = datas.filter((data) => {
+        if (!data.output.output) {
+            console.error(`ok - skipping ${JSON.stringify(data)} - no successful output to fetch`);
+            return false;
+        }
+        return true;
+    });
+
     const stats = {
         count: 0,
         sources: datas.length

--- a/task/fabric.js
+++ b/task/fabric.js
@@ -168,6 +168,9 @@ async function cli() {
                 if (!layers.includes(data.layer)) {
                     console.error(`ok - skipping ${JSON.stringify(data)} due to unsupported layer type`);
                     return false;
+                } else if (!data.output.output) {
+                    console.error(`ok - skipping ${JSON.stringify(data)} - no successful output to fetch`);
+                    return false;
                 }
                 return true;
             });


### PR DESCRIPTION
## Summary

Fixes #628.

`/api/data` (and the batch dashboard's "Individual Sources" table) only lists a source/layer if it has a row in the `results` table — and a row only gets written the first time a live-run job for that source/layer/name succeeds. A layer that has never succeeded (e.g. `us/il/sangamon` parcels, which has been failing every live run for months due to the upstream ArcGIS endpoint timing out) therefore never appears at all, with no way for a contributor to discover or debug it from the dashboard.

`Data.list()` can now also surface the latest `Fail`ed job for any source/layer/name combo that has no `results` row, gated behind a new opt-in `?failing=true` query param that only the dashboard passes. Since there's no successful run to report a date for, `updated` is `null` and the frontend shows "No successful run" in place of the date. These synthetic rows use a negative `id` (there's no real `results` row backing them) and hide the admin/history controls that require one, but the download icon still naturally hides itself since `job.output.output` is `false` for a failed job, and clicking the row still opens the actual failing job so a contributor can read the log.

Things this had to be careful not to break, all with explicit regression coverage:
- **`task/collect.js` and `task/fabric.js`** both call this same endpoint with no query params to build the downloadable collection ZIPs / fabric tiles. Making the failing rows opt-in means their behavior is byte-for-byte unchanged - they never ask for `failing=true`. As defense in depth (so this doesn't silently depend on that default forever), both scripts also now explicitly skip any entry whose `output.output` is falsy before attempting the S3 fetch, rather than relying on a `NoSuchKey` catch after the fact.
- **`Data.update()`** (called after every successful job to write/refresh the `results` row) and **`Job.delta()`** both call `Data.list()` with `exact: true` as an internal "does a real results row already exist" lookup. Without care, a synthetic failing row could get misread as "yes, a row exists," turning what should be an `INSERT` into a silent no-op `UPDATE` - i.e. a source that finally succeeds after a run of failures would never get its first `results` row written. `includeFailing` is forced off whenever `exact` is set, so these lookups only ever see genuine `results` rows.

Restricted to `job.status = 'Fail'` (not "no results row" generally) so a layer whose very first job is merely `Pending`/`Running` isn't flagged as broken before it's had a chance to run.

## Test plan
- [x] Ran the full `api/test/run.srv.test.js` suite against a local Postgres/PostGIS before and after the change — same 8/9 pass (the 1 pre-existing failure is unrelated, present on `master` too).
- [x] Manually verified `Data.list()` against fixture data with one succeeded layer and one layer with two failed jobs: the succeeded layer returns its normal `results` row, the always-failing layer returns a synthetic row pointing at the *latest* failing job with `updated: null`.
- [x] Manually verified the default (no `failing` param) call returns identically to before the change, matching what `collect.js`/`fabric.js` use.
- [x] Manually verified `Data.update()` on a source with two prior failures followed by a success correctly `INSERT`s a fresh `results` row rather than silently no-op-`UPDATE`ing.