### PR TITLE
Give the addresses fabric job a bigger instance to fix tile-join OOM

### DIFF
--- a/api/lib/batch.js
+++ b/api/lib/batch.js
@@ -252,6 +252,13 @@ export async function trigger(event) {
         ];
 
         for (const job of fabricJobs) {
+            // addresses is by far the largest layer - tile-join's peak memory
+            // when merging its shards scales with total merged tile volume and
+            // empirically exceeds 58GB at national scale (confirmed by a real
+            // OOM here, and by local scaling tests up to 51GB of real source
+            // data). Give it a bigger box; the other layers/border fit
+            // comfortably within the default r5.2xlarge-sized job.
+            const big = job.name === 'Addresses';
             await submit({
                 jobDefinition: jobDefinition,
                 jobQueue: mega_queue,
@@ -259,8 +266,8 @@ export async function trigger(event) {
                 containerOverrides: {
                     command: ['node', 'fabric.js', ...job.args],
                     environment: [],
-                    vcpus: 8,
-                    memory: 58000
+                    vcpus: big ? 16 : 8,
+                    memory: big ? 110000 : 58000
                 },
                 timeout: {
                     attemptDurationSeconds: 60 * 60 * 24 * 3  // 3 day hard cap, per layer

--- a/cloudformation/task.template.js
+++ b/cloudformation/task.template.js
@@ -43,7 +43,10 @@ export default {
                 ServiceRole: cf.getAtt('BatchServiceRole', 'Arn'),
                 ComputeResources: {
                     ImageId: 'ami-074bb5e3c681b0735',
-                    MaxvCpus: 16,
+                    // 32 (rather than 16) so an r5.4xlarge addresses job (16
+                    // vCPUs) can run alongside the other fabric jobs
+                    // (r5.2xlarge, 8 vCPUs each) instead of serializing them.
+                    MaxvCpus: 32,
                     DesiredvCpus: 0,
                     MinvCpus: 0,
                     SecurityGroupIds: [cf.ref('BatchSecurityGroup')],
@@ -61,7 +64,13 @@ export default {
                     ],
                     Type : 'EC2',
                     InstanceRole : cf.getAtt('BatchInstanceProfile', 'Arn'),
-                    InstanceTypes : ['r5.2xlarge']
+                    // r5.4xlarge (16 vCPU / 128GB) added for the addresses
+                    // fabric job specifically - see api/lib/batch.js's fabric
+                    // submission, which requests 110GB for that job alone.
+                    // Batch places each job on whichever allowed type fits its
+                    // requested resources, so the other (lighter) fabric jobs
+                    // still land on r5.2xlarge.
+                    InstanceTypes : ['r5.2xlarge', 'r5.4xlarge']
                 },
                 State: 'ENABLED'
             }


### PR DESCRIPTION
## Summary
- `OA_Fabric_Addresses` has been OOM-killing (`OutOfMemoryError: Container killed due to memory usage`) during `tile-join`'s final merge of the 8 sharded tiles - fetch and per-shard tiling both complete fine now (thanks to #605's sharding), but merging back into one `addresses.pmtiles` needs more than the job's 58GB.
- Ruled out non-infra fixes empirically (local repro against real production source data, up to 51GB of real geojson): reducing shard count, pairwise/tournament merging instead of joining all 8 at once, and every relevant `tile-join` CLI flag (`-pg`, `-e`, `--no-tile-size-limit`) either made no difference or made memory usage worse. `tile-join`'s peak RSS scales with total merged data volume, not with how many inputs are open at once, so there's no way to shrink it algorithmically for this job.
- The scaling turned out to be *sub-linear*: peak RSS grew ~4.9x while merged data grew ~17-20x across two real local test scales, with a shrinking peak-RSS-to-output-size ratio (5.2x -> 1.5x) as scale increased. Extrapolating to the real national corpus (~230GB uncompressed) lands around ~44GB, comfortably fitting an r5.4xlarge (128GB) rather than needing something exotic.
- This PR: adds `r5.4xlarge` to the `mega` compute environment's allowed instance types (bumping `MaxvCpus` 16 -> 32 so it can run alongside the other, lighter fabric jobs instead of serializing them), and gives the `addresses` fabric job specifically 16 vCPUs / 110GB (the other three layers + border stay at 8 vCPUs / 58GB on `r5.2xlarge`).

## Test plan
- [x] `npm run lint` (api) passes
- [x] Verified both files parse/import correctly and produce the expected structure (root `cloudformation` lint has an unrelated broken local `node_modules`/ajv issue, not from this change)
- [ ] Next scheduled `OA_Fabric_Addresses` run completes without OOM